### PR TITLE
fix(scripts): gen-types 按平台选择 tsc 命令，并修掉挡住类型生成的 tsc 错误

### DIFF
--- a/dsh-pet/scripts/gen-types.mjs
+++ b/dsh-pet/scripts/gen-types.mjs
@@ -21,8 +21,18 @@ const HOST_OUT = join(TYPES, 'host');
 rmSync(TYPES, { recursive: true, force: true });
 mkdirSync(TYPES, { recursive: true });
 
-const tsc = spawnSync('cmd /c npx tsc -p tsconfig.types.json', { cwd: ROOT, stdio: 'inherit', shell: true });
-if (tsc.status !== 0) process.exit(tsc.status);
+// Windows 下 npm/npx 是 .cmd，spawnSync 无法直接执行；用 cmd /c 跑整条命令。
+// 非 Windows（linux/darwin）直接跑即可——之前这里无条件用 cmd /c，
+// 导致类 unix 平台上 spawnSync 拿到 shell 的 127（cmd: command not found），
+// 而 TYPES 目录在本文件开头已被清空，结果是「声明被删掉却没重新生成」。
+// 写法与 scripts/prepare.js 保持一致。
+const tscRun =
+  process.platform === 'win32' ? 'cmd /c npx tsc -p tsconfig.types.json' : 'npx tsc -p tsconfig.types.json';
+const tsc = spawnSync(tscRun, { cwd: ROOT, stdio: 'inherit', shell: true });
+if (tsc.status !== 0) {
+  console.error(`[gen-types] 类型声明生成失败 (exit ${tsc.status})`);
+  process.exit(tsc.status ?? 1);
+}
 
 // 宿主半侧声明上移到 lib/types/ 根（lib/types/index.d.ts），client 子树保持不变。
 if (existsSync(HOST_OUT)) {

--- a/dsh-pet/src/host/helper-process.ts
+++ b/dsh-pet/src/host/helper-process.ts
@@ -17,11 +17,16 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve, sep } from 'node:path';
 import { Readable, Transform } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
+import { pipeline as pipelineCallback } from 'node:stream';
+import { promisify } from 'node:util';
 import { tmpdir } from 'node:os';
 import { symlinkSync, writeFileSync } from 'node:fs';
 
 const require = createRequire(import.meta.url);
+/** stream 的回调版 pipeline + promisify：与 stream/promises 同实现，但类型只认 Node 流，
+ *  避开 @types/node 26.x 里 stream/promises.pipeline 与 DOM lib 的 ReadableStream 定义冲突。 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- 重载歧义无法用具体类型表达，见下方调用处注释
+const nodePipeline = promisify(pipelineCallback) as unknown as (...streams: any[]) => Promise<void>;
 const here = dirname(fileURLToPath(import.meta.url));
 export const packageRoot = resolve(here, '..');
 export const defaultHelperMain = resolve(packageRoot, 'runtime', 'electron-helper', 'main.js');
@@ -463,7 +468,11 @@ export async function ensureElectronDownload(options: EnsureElectronOptions = {}
           callback(null, chunk);
         },
       });
-      await pipeline(
+      // @types/node 26.x + tsconfig lib 含 DOM 时，stream/promises 的 pipeline
+      // 存在重载歧义：三参数链条的末位会被当成 PipelineOptions（报 TS2345/TS2769）。
+      // 运行时行为完全正确（下载链路已端到端实测），这里改用 node:stream 的回调版
+      // pipeline + promisify，绕开重载选择问题。
+      await nodePipeline(
         Readable.fromWeb(response.body as import('node:stream/web').ReadableStream),
         progress,
         createWriteStream(zipPath),


### PR DESCRIPTION
承接 #30 合并后 @PC2005-cloud 的留言：`scripts/gen-types.mjs` 硬编码 `cmd /c`，你建议按 `scripts/prepare.js` 的做法加平台判断 —— 已照做，见改动 1。

不过**只改这一处是不够的**：平台修好后 tsc 真的跑起来了，立刻撞上另一个 blocker
（既有的 tsc 类型错误），类型声明照样生成不了。所以本 PR 一并修了，见改动 2。

Closes #29 的遗留项。

---

fix(scripts): gen-types 平台判断 + 修 blocker 级 tsc 类型错误

承接 #30 合并后 maintainer 的留言：gen-types.mjs 硬编码 `cmd /c`，
导致 Linux/macOS 上 prepare 钩子生成类型声明失败。

## 1. gen-types.mjs：tsc 命令按平台选择

```js
- const tsc = spawnSync('cmd /c npx tsc -p tsconfig.types.json', ...);
+ const tscRun = process.platform === 'win32'
+   ? 'cmd /c npx tsc -p tsconfig.types.json'
+   : 'npx tsc -p tsconfig.types.json';
```

写法与 scripts/prepare.js（34/43/52 行）保持一致。

**为什么这个 bug 比看起来严重**：本文件第 21 行会先 `rmSync(TYPES)` 清空
`lib/types`，再跑 tsc。命令失败后不是「保留旧的声明」，而是
**「旧的被删掉了，新的没生成」** —— 落一个空目录。加上 prepare 是
npm install / npm publish 的自动钩子，用户在类 unix 平台上会发现
`lib/types/index.d.ts` 直接不存在（package.json exports 指向它）。

失败时补了明确的错误日志（原来只有 exit code，看不出是哪一步断的）。

## 2. helper-process.ts：顺带修掉挡住 tsc 的既有类型错误

只改 gen-types 是不够的 —— 平台修好后 tsc 真的跑起来了，立刻撞上另一个 blocker：

```
src/host/helper-process.ts(467,9): error TS2769: No overload matches this call.
  Argument of type 'Readable' is not assignable to parameter of type 'PipelineSource<any>'.
    Type 'Readable' is not assignable to type 'ReadableStream'.
      The types returned by '[Symbol.asyncIterator]()' are incompatible...
```

这在 #30 之前就存在（baseline 284 行），只是当时非 Windows 平台上
`npm run types` 根本没跑到 tsc，所以一直没暴露。

根因：`tsconfig.json` 的 lib 含 `DOM`，DOM 的 `ReadableStream` 成为全局类型，
与 `stream/promises` pipeline 的 `PipelineSource` 判定冲突；在
@types/node 26.x 下三参数链条还会出现「末位参数被当成 PipelineOptions」的重载歧义。

修法：改用 `node:stream` 的回调版 pipeline + promisify（与 stream/promises
同一实现），并把这个包装的类型声明为接受任意流元组 —— 仅类型层绕开重载歧义，
运行时行为完全不变（下载链路已端到端回归，见下）。

## 验证（本机 linux-x64，GNU tar 1.30，@types/node 26.2.0）

| 项目 | 结果 |
|---|---|
| 修复前 `npm run types` | `/bin/sh: cmd: command not found`，lib/types 被清空且未重建 |
| 修复后 `npm run types` | `[gen-types] ✓ lib/types 声明生成完成`，23 个 .d.ts |
| `lib/types/index.d.ts` | ✅ 宿主声明正确上移到根（原为不存在） |
| `lib/types/client/index.d.ts` | ✅ |
| `tsc --noEmit` | ✅ 零错误（此前 1 个） |
| `tsc -p tsconfig.test.json` | ✅ 零错误 |
| `npm test` | ✅ 10/10 通过 |
| `eslint .` | ✅ 无告警 |
| `prettier --check` | ✅ 改动文件合规 |
| **端到端回归** | ✅ 真实下载 119.8MB → 14.3s 完成解压，产出 220,986,616 字节的 ELF 可执行文件 |

端到端回归是必要的：本次改动碰了下载链路的 pipeline 实现，必须确认
「类型修好了但下载没坏」。

## 备注

- 本次不含功能改动，仅修构建链路与类型。
- 未处理：`lib` 含 `DOM` 与宿主侧（Node）代码共用一份 tsconfig 的结构性问题。
  本次是在现有结构下的最小修复；若要根治，建议给 host / client 拆 tsconfig
  （client 需要 DOM，host 不需要），可以另开 issue 讨论。

---

## 另：一个与本次修复相关的发现（供参考，非本 PR 范围）

在 Linux 无显示器环境下，`display: "both"` 会让 Helper 反复拉起 Electron 又崩溃，
每个 core dump 约 13MB，配合守护循环的自动重启，我这边几小时内堆到了 **79GB**。
因为 `core_pattern` 是 `core`（落在进程 CWD），而 Helper 的 CWD 是插件包目录。

不是 dsh-pet 的 bug（无 GUI 环境本来就不该开桌面模式），但如果以后有用户在
服务器上跑 dsh web，这是个容易踩的坑。是否需要加个「无 DISPLAY 时跳过桌面 Helper
启动并提示」的保护，看你的判断，我可以另开 PR。