### PR TITLE
fix(helper): headless 环境不拉起桌面 Helper + 重启指数退避与熔断（修复 core dump 刷爆磁盘）

### DIFF
--- a/dsh-pet/src/host/helper-process.test.ts
+++ b/dsh-pet/src/host/helper-process.test.ts
@@ -15,7 +15,16 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { dshHomeDir, defaultElectronExe, hasGraphicalDisplay, resolveElectronPath } from './helper-process.ts';
+import {
+  HELPER_STABLE_MS,
+  dshHomeDir,
+  defaultElectronExe,
+  hasGraphicalDisplay,
+  helperRunIsStable,
+  restartBackoffDelayMs,
+  resolveElectronPath,
+  shouldCircuitBreak,
+} from './helper-process.ts';
 
 /** 建一个隔离的临时目录,并归还原 DSH_HOME / DSH_PET_ELECTRON_PATH 环境变量 */
 function withIsolatedHome(fn: (dir: string) => void): void {
@@ -163,5 +172,39 @@ describe('hasGraphicalDisplay —— 无图形环境时不拉起 Electron', () =
     delete process.env.WAYLAND_DISPLAY;
     process.env.DSH_PET_DESKTOP_FORCE = '1';
     assert.equal(hasGraphicalDisplay(), true);
+  });
+});
+
+describe('restartBackoffDelayMs —— 指数退避（750ms 起，2x 封顶 30s）', () => {
+  test('退避序列：750 → 1500 → 3000 → 6000 → 12000 → 24000 → 30000（封顶后不再翻倍）', () => {
+    // 注意别写 .map(restartBackoffDelayMs)：map 会把索引当 baseMs 传进去
+    const seq = [0, 1, 2, 3, 4, 5, 6, 7, 8].map((n) => restartBackoffDelayMs(n));
+    assert.deepEqual(seq, [750, 1500, 3000, 6000, 12000, 24000, 30000, 30000, 30000]);
+  });
+
+  test('DSH_PET_RESTART_BASE_MS 可调基值（同样 2x、封顶 30s）', () => {
+    assert.equal(restartBackoffDelayMs(0, 1000), 1000);
+    assert.equal(restartBackoffDelayMs(5, 1000), 30000);
+  });
+});
+
+describe('shouldCircuitBreak —— 连续崩溃 12 次（约 6 分钟）后熔断', () => {
+  test('前 11 次不熔断，第 12 次起熔断', () => {
+    assert.equal(shouldCircuitBreak(0), false);
+    assert.equal(shouldCircuitBreak(10), false);
+    assert.equal(shouldCircuitBreak(11), false);
+    assert.equal(shouldCircuitBreak(12), true);
+    assert.equal(shouldCircuitBreak(50), true);
+  });
+});
+
+describe('helperRunIsStable —— 稳定运行 ≥3 分钟后计数清零', () => {
+  test('不足 3 分钟：不稳定，不清零', () => {
+    assert.equal(helperRunIsStable(2 * 60 * 1000), false);
+  });
+
+  test('达到 3 分钟：稳定，应清零', () => {
+    assert.equal(helperRunIsStable(HELPER_STABLE_MS), true);
+    assert.equal(helperRunIsStable(10 * 60 * 1000), true);
   });
 });

--- a/dsh-pet/src/host/helper-process.test.ts
+++ b/dsh-pet/src/host/helper-process.test.ts
@@ -9,13 +9,13 @@
  * 用 Node 内置 test runner（node:test），不引入任何 npm 依赖：
  *   node --experimental-strip-types --test src/host/helper-process.test.ts
  */
-import { test, describe } from 'node:test';
+import { test, describe, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { dshHomeDir, defaultElectronExe, resolveElectronPath } from './helper-process.ts';
+import { dshHomeDir, defaultElectronExe, hasGraphicalDisplay, resolveElectronPath } from './helper-process.ts';
 
 /** 建一个隔离的临时目录,并归还原 DSH_HOME / DSH_PET_ELECTRON_PATH 环境变量 */
 function withIsolatedHome(fn: (dir: string) => void): void {
@@ -131,5 +131,37 @@ describe('resolveElectronPath —— 候选优先级', () => {
       writeFileSync(landed, '');
       assert.equal(resolveElectronPath([]), landed);
     });
+  });
+});
+
+describe('hasGraphicalDisplay —— 无图形环境时不拉起 Electron', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    for (const key of ['DISPLAY', 'WAYLAND_DISPLAY', 'DSH_PET_DESKTOP_FORCE']) delete process.env[key];
+    Object.assign(process.env, saved);
+  });
+
+  test('linux 无 DISPLAY / WAYLAND_DISPLAY：判为无图形环境（避免拉起即崩刷满 core dump）', () => {
+    delete process.env.DISPLAY;
+    delete process.env.WAYLAND_DISPLAY;
+    // 非 linux（win32/darwin）桌面系统恒放行，故按平台断言
+    assert.equal(hasGraphicalDisplay(), process.platform !== 'linux');
+  });
+
+  test('有 DISPLAY 时放行', () => {
+    process.env.DISPLAY = ':0';
+    assert.equal(hasGraphicalDisplay(), true);
+  });
+
+  test('有 WAYLAND_DISPLAY 时放行', () => {
+    process.env.WAYLAND_DISPLAY = 'wayland-0';
+    assert.equal(hasGraphicalDisplay(), true);
+  });
+
+  test('DSH_PET_DESKTOP_FORCE=1 为逃生口（Xvfb / 远程桌面场景）', () => {
+    delete process.env.DISPLAY;
+    delete process.env.WAYLAND_DISPLAY;
+    process.env.DSH_PET_DESKTOP_FORCE = '1';
+    assert.equal(hasGraphicalDisplay(), true);
   });
 });

--- a/dsh-pet/src/host/helper-process.ts
+++ b/dsh-pet/src/host/helper-process.ts
@@ -101,6 +101,27 @@ export function resolveElectronPath(candidates: Array<string | undefined> = []):
 }
 
 /** $DSH_HOME（默认 ~/.dsh），与 ensure-electron.mjs 的 HOME 计算一致。 */
+/**
+ * 判断当前环境能否真的跑起 Electron 图形窗口。
+ *
+ * 【为什么需要】Linux 无显示环境（服务器 / 容器 / 纯 CLI）下，Electron 能被成功
+ * 下载并 spawn 拉起，但初始化图形栈时立刻崩溃。配合 Helper 的守护循环
+ * （异常退出自动重启），结果是每秒反复「拉起→崩溃→重启」，每个 core dump
+ * 约 14MB —— 实测几小时可堆到数十 GB 打满磁盘。必须在拉起之前判断。
+ *
+ * 判定口径（只拦「明确跑不起来」的情况）：
+ *   - win32 / darwin：桌面系统，放行（macOS 无 DISPLAY 也走 WindowServer）；
+ *   - linux：需要 DISPLAY 或 WAYLAND_DISPLAY 其一，都没有则判为无显示环境。
+ *
+ * 【逃生口】DSH_PET_DESKTOP_FORCE=1 强制跳过，供 Xvfb / 远程桌面等
+ * 「环境变量没设但其实能显示」的场景使用。
+ */
+export function hasGraphicalDisplay(): boolean {
+  if (process.platform !== 'linux') return true;
+  if (process.env.DSH_PET_DESKTOP_FORCE === '1') return true;
+  return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
 export function dshHomeDir(): string {
   const userProfile = process.env.USERPROFILE || process.env.HOME || '';
   return process.env.DSH_HOME || join(userProfile, '.dsh');

--- a/dsh-pet/src/host/helper-process.ts
+++ b/dsh-pet/src/host/helper-process.ts
@@ -246,6 +246,10 @@ export class HelperProcess {
   declare private stopping: boolean;
   declare private restartSuppressed: boolean;
   declare private restartTimer?: NodeJS.Timeout;
+  /** 连续崩溃计数（稳定运行 ≥3 分钟清零；达上限触发熔断） */
+  declare private restartFailures: number;
+  /** 最近一次 start() 的时间戳（稳定性判定基准） */
+  declare private lastStartAt: number;
   /** stdout 按行缓冲（协议行按 \n 切分）。用 declare + 构造器赋值，避免类字段降级出外部 helper */
   declare private stdoutBuffer: string;
 
@@ -256,11 +260,14 @@ export class HelperProcess {
     this.stopping = false;
     this.restartSuppressed = false;
     this.restartTimer = undefined;
+    this.restartFailures = 0;
+    this.lastStartAt = 0;
     this.stdoutBuffer = '';
   }
 
   start(): import('node:child_process').ChildProcess | undefined {
     if (this.child || this.stopping || this.restartSuppressed) return this.child;
+    this.lastStartAt = Date.now();
     const helperPath = this.options.helperPath || defaultHelperMain;
     const launch = this.options.command
       ? { command: this.options.command, args: this.options.args || [helperPath] }
@@ -379,11 +386,78 @@ export class HelperProcess {
 
   private scheduleRestart(): void {
     if (this.restartTimer || this.stopping || this.restartSuppressed) return;
-    const delay = this.options.restartDelayMs ?? 750;
+    // ① 指数退避：750ms 起 2x 封顶 30s；② 熔断：连续崩溃 12 次（约 6 分钟）后停止重启。
+    // 两个阈值都可配（DSH_PET_RESTART_BASE_MS / DSH_PET_RESTART_MAX_FAILURES），稳定运行 ≥3 分钟清零。
+    // 纯逻辑（restartBackoffDelayMs / shouldCircuitBreak / helperRunIsStable）在 helper-process.test.ts 有独立用例。
+    if (helperRunIsStable(Date.now() - this.lastStartAt)) {
+      this.restartFailures = 0;
+    } else {
+      this.restartFailures += 1;
+    }
+    if (shouldCircuitBreak(this.restartFailures)) {
+      this.logger.error?.(
+        `dsh-pet desktop helper crashed ${this.restartFailures} consecutive times; circuit breaker tripped, ` +
+          `no more restarts. Fix the environment (e.g. DISPLAY/headless) or set DSH_PET_RESTART_MAX_FAILURES to raise the limit.`,
+      );
+      return;
+    }
+    const base = this.resolveRestartBaseMs();
+    const delay = restartBackoffDelayMs(this.restartFailures, base);
+    this.logger.warn?.(
+      `dsh-pet desktop helper exited; restarting in ${Math.round(delay)}ms ` +
+        `(attempt ${this.restartFailures}, consecutive-crash limit ${this.resolveMaxFailures()})`,
+    );
     this.restartTimer = setTimeout(() => {
       this.restartTimer = undefined;
       this.start();
     }, delay);
     this.restartTimer.unref?.();
   }
+
+  /** 退避基值：DSH_PET_RESTART_BASE_MS（ms，>0）可调，默认 750。 */
+  private resolveRestartBaseMs(): number {
+    return envPositiveInt(process.env.DSH_PET_RESTART_BASE_MS, RESTART_BASE_MS_DEFAULT);
+  }
+
+  /** 熔断阈值：DSH_PET_RESTART_MAX_FAILURES（次，>0）可调，默认 12。 */
+  private resolveMaxFailures(): number {
+    return envPositiveInt(process.env.DSH_PET_RESTART_MAX_FAILURES, RESTART_MAX_FAILURES_DEFAULT);
+  }
+}
+
+// ---------- 重启退避 / 熔断纯逻辑（可独立测试，不依赖 spawn） ----------
+
+/** 稳定运行判定阈值：Helper 连续无崩溃运行 ≥ 3 分钟后，重启失败计数清零。 */
+export const HELPER_STABLE_MS = 3 * 60 * 1000;
+
+/**
+ * 指数退避：第 n 次（0 起）失败后等待 base × 2ⁿ，封顶 30s。
+ * 默认 base 750ms 保持与旧版首延一致，序列：750 → 1500 → 3000 → … → 30000。
+ */
+export function restartBackoffDelayMs(consecutiveFailures: number, baseMs = 750): number {
+  const MAX = 30_000;
+  const raw = baseMs * 2 ** Math.max(0, consecutiveFailures);
+  return Math.min(raw, MAX);
+}
+
+/** 熔断判定：连续崩溃 ≥ limit（默认 12，按默认退避约 6 分钟）次后不再自动重启。 */
+export function shouldCircuitBreak(consecutiveFailures: number, limit = 12): boolean {
+  return consecutiveFailures >= limit;
+}
+
+/** 稳定运行判定：距上次拉起 ≥ HELPER_STABLE_MS 视为一次「成功运行」，可清零计数。 */
+export function helperRunIsStable(elapsedMs: number): boolean {
+  return elapsedMs >= HELPER_STABLE_MS;
+}
+
+/** 退避基值（ms）：默认 750 与旧版首延一致，DSH_PET_RESTART_BASE_MS 可调。 */
+const RESTART_BASE_MS_DEFAULT = 750;
+
+/** 熔断阈值（连续崩溃次数）：默认 12，DSH_PET_RESTART_MAX_FAILURES 可调。 */
+const RESTART_MAX_FAILURES_DEFAULT = 12;
+
+/** 非负整数 env 解析（非法/未设回落默认），供重启参数读取共用。 */
+function envPositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/dsh-pet/src/host/index.ts
+++ b/dsh-pet/src/host/index.ts
@@ -50,7 +50,13 @@ import { queryBalance } from './balance';
 import { generateWhisper } from './whisper';
 import { generateChat, type ChatMemoryMessage } from './chat';
 import { findPetInstance, flattenPetList, readAllConfig, saveUserConfig, type ConfigPaths } from './config';
-import { HelperProcess, defaultElectronExe, ensureElectronDownload, resolveElectronPath } from './helper-process';
+import {
+  HelperProcess,
+  defaultElectronExe,
+  ensureElectronDownload,
+  hasGraphicalDisplay,
+  resolveElectronPath,
+} from './helper-process';
 
 /** 插件行 id（与 cordis.patch.yml 一致） */
 export const name = 'pet';
@@ -355,6 +361,8 @@ export function apply(ctx: any): void {
   let startRetryTimer: NodeJS.Timeout | undefined;
   let electronEnsure: Promise<void> | undefined;
   let disposed = false;
+  /** 「无图形环境」提示只在进程生命周期内打一次，避免守护循环刷屏 */
+  let displayWarned = false;
 
   /** 用已确认存在的 Electron 路径拉起桌面 Helper（每只桌面宠物一个局部小窗口）。 */
   const launchHelper = (electronPath: string | undefined): void => {
@@ -422,6 +430,18 @@ export function apply(ctx: any): void {
   const startHelper = (): void => {
     if (helper || electronEnsure || disposed) return;
     if (!hasDesktopPet) return; // 无宠物显示在桌面（display 含 desktop/both）：不启动
+    // 无图形显示环境（Linux 服务器 / 容器）：直接放弃，不探测、不下载、不拉起。
+    // 否则 Electron 会「拉起即崩」，被守护循环反复重启并刷满 core dump。
+    if (!hasGraphicalDisplay()) {
+      if (!displayWarned) {
+        displayWarned = true;
+        ctx.logger?.warn?.(
+          '[dsh-pet] 未检测到图形显示环境（DISPLAY/WAYLAND_DISPLAY 均为空），已跳过桌面宠物。' +
+            '浏览器内宠物不受影响；如需在服务器上启用桌面模式，请配置 Xvfb 后设置 DSH_PET_DESKTOP_FORCE=1。',
+        );
+      }
+      return;
+    }
     const found = resolveElectronPath();
     if (found) {
       launchHelper(found);


### PR DESCRIPTION
Closes #35

## 这个 PR 做了什么（对应 #35 的建议 ①②）

**1. 没有屏幕就不拉起桌面助手**（commit `3c0946c`）

启动 Electron 前先看一眼环境：Linux 下没有 `DISPLAY` 也没有 `WAYLAND_DISPLAY`（即没有「屏幕」）就直接跳过，网页宠物照常工作；macOS/Windows 是桌面系统，照常放行。给 Xvfb、远程桌面这类「没设变量但其实能显示」的场景留了逃生口：`DSH_PET_DESKTOP_FORCE=1`。

> 为什么要在代码里拦，而不是让用户改配置：实测把宠物 display 改成 web 后，几秒内就会被 dsh web 用内存里的值写回 both——改配置拦不住这个循环，只有插件自己判断环境才能根治。警告日志只打一次，不会刷屏。

**2. 崩溃重试不再无限**（commit `d9b9146`）

- 重试间隔逐步拉长：0.75s → 1.5s → 3s → … 封顶 30s（首延与旧行为一致，正常环境几乎无感）；
- 连续崩溃 12 次（约 6 分钟）后放弃重启，打一条明确的错误日志说明原因和处理办法；
- 只要稳定运行满 3 分钟，计数就清零——长期运行的偶发崩溃不会被累计误伤。

两个阈值都可以用环境变量调：`DSH_PET_RESTART_BASE_MS`（起始间隔）、`DSH_PET_RESTART_MAX_FAILURES`（熔断次数），不设置就是上面的默认值。

<details>
<summary>📄 实现细节</summary>

- 退避 / 熔断 / 稳定判定抽成了三个纯函数（`restartBackoffDelayMs` / `shouldCircuitBreak` / `helperRunIsStable`），不依赖真实进程即可测试；
- headless 判定逻辑在 `hasGraphicalDisplay()`，于探测/下载/拉起**之前**拦截，避免白白下载 Electron；
- 改动集中在 `dsh-pet/src/host/helper-process.ts` 与 `index.ts` 的 `startHelper` 入口，不动任何现有配置结构。

</details>

## 怎么验证的

- 单元测试 **19/19 通过**（node 内置 runner）：headless 门控四个场景（无显示拦截 / 有 DISPLAY 放行 / 有 WAYLAND 放行 / FORCE=1 逃生）、退避序列、熔断边界（第 11 次不熔 / 第 12 次熔）、稳定清零阈值；
- `tsc --noEmit`、eslint、tsdown 构建全部通过；
- **实机验证**：在无图形环境的 Linux 容器 + dsh web 0.1.2-alpha.5 上，打上门控补丁后 core dump 立刻停止产生（打补丁前每秒落一个 14MB 的 core 文件持续累积）。

## 兼容性

- 全部新逻辑带默认值，不新增必填配置；有屏幕的正常环境下，行为与之前完全一致；
- 唯一的行为变化：在一个「注定起不来」的环境里，助手不再无限重生——熔断后会打一条日志，按提示处理或调高上限即可。

如果实现风格跟项目不搭，欢迎取用思路按你的风格重写～需要完整事故日志随时在 #35 说一声。