### PR TITLE
fix(desktop): 双屏拖拽/抛甩不再骑缝分身闪烁

### DIFF
--- a/dsh-pet/runtime/electron-helper/constants.js
+++ b/dsh-pet/runtime/electron-helper/constants.js
@@ -28,6 +28,24 @@ const VIEW = {
   w: Number(params.get('workAreaW') || (window.screen && window.screen.availWidth) || 1920),
   h: Number(params.get('workAreaH') || (window.screen && window.screen.availHeight) || 1080),
 };
+// 各屏 bounds + workArea（主进程 deskDisplays）。多屏时窗口整块落在其中一块上；
+// 解析失败回落到 VIEW 单屏，单显示器行为与以前一致。
+const DISPLAYS = (function resolveDisplays() {
+  const parsed = S.parseDisplays ? S.parseDisplays(params.get('displays')) : [];
+  if (parsed.length) return parsed;
+  return [
+    {
+      x: VIEW.x,
+      y: VIEW.y,
+      width: VIEW.w,
+      height: VIEW.h,
+      workX: VIEW.x,
+      workY: VIEW.y,
+      workW: VIEW.w,
+      workH: VIEW.h,
+    },
+  ];
+})();
 const ORIGIN = new URL(CONFIG.configUrl).origin;
 /** 宿主 /dsh-pet-7340 前缀：bridge 走自定义 scheme（主进程转发），否则 HTTP 直连宿主 */
 const BASE = BRIDGE ? 'dsh-pet-bridge://dsh-pet/dsh-pet-7340' : ORIGIN + '/dsh-pet-7340';

--- a/dsh-pet/runtime/electron-helper/main.js
+++ b/dsh-pet/runtime/electron-helper/main.js
@@ -146,8 +146,69 @@ function deskWorkArea() {
   return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
 }
 
+/** 每块屏的 bounds + workArea（DIP），给渲染端做单屏落窗 / 按真实工作区抛掷 */
+function deskDisplays() {
+  return screen.getAllDisplays().map((d) => {
+    const b = d.bounds;
+    const a = d.workArea;
+    return {
+      x: b.x,
+      y: b.y,
+      width: b.width,
+      height: b.height,
+      workX: a.x,
+      workY: a.y,
+      workW: a.width,
+      workH: a.height,
+    };
+  });
+}
+
+/**
+ * 窗口必须整块落在「中心所在屏」的 bounds 内。
+ * 透明分层窗骑在屏缝上时，Windows DWM 会在两块屏同时合成，拖过缝 / 副屏抛甩就会分身闪烁。
+ */
+function fitBoundsToNearestDisplay(bounds) {
+  const displays = deskDisplays();
+  if (!displays.length) return bounds;
+  const cx = bounds.x + bounds.width / 2;
+  const cy = bounds.y + bounds.height / 2;
+  let nearest = displays[0];
+  let best = Infinity;
+  for (const d of displays) {
+    const inside = cx >= d.x && cx < d.x + d.width && cy >= d.y && cy < d.y + d.height;
+    if (inside) {
+      nearest = d;
+      best = 0;
+      break;
+    }
+    const px = Math.min(Math.max(cx, d.x), d.x + d.width - 1);
+    const py = Math.min(Math.max(cy, d.y), d.y + d.height - 1);
+    const dist = (px - cx) * (px - cx) + (py - cy) * (py - cy);
+    if (dist < best) {
+      best = dist;
+      nearest = d;
+    }
+  }
+  let { x, y, width, height } = bounds;
+  if (width <= nearest.width) {
+    if (x < nearest.x) x = nearest.x;
+    if (x + width > nearest.x + nearest.width) x = nearest.x + nearest.width - width;
+  } else {
+    x = nearest.x;
+  }
+  if (height <= nearest.height) {
+    if (y < nearest.y) y = nearest.y;
+    if (y + height > nearest.y + nearest.height) y = nearest.y + nearest.height - height;
+  } else {
+    y = nearest.y;
+  }
+  return { x, y, width, height };
+}
+
 function createPetWindows() {
   const area = deskWorkArea();
+  const displays = deskDisplays();
   const configUrl = process.env.DSH_PET_CONFIG_URL || 'http://127.0.0.1:3080/dsh-pet-7340/config';
   const pets = petsFromEnv();
   for (const pet of pets) {
@@ -202,6 +263,7 @@ function createPetWindows() {
           workAreaH: String(area.height),
           workAreaX: String(area.x),
           workAreaY: String(area.y),
+          displays: JSON.stringify(displays),
         },
       })
       .catch((error) => {
@@ -336,10 +398,21 @@ app.whenReady().then(() => {
     const width = Number(bounds?.width);
     const height = Number(bounds?.height);
     if (![x, y, width, height].every(Number.isFinite)) return;
-    win.setContentBounds(
-      { x: Math.round(x), y: Math.round(y), width: Math.round(width), height: Math.round(height) },
-      false,
-    );
+    const raw = {
+      x: Math.round(x),
+      y: Math.round(y),
+      width: Math.round(width),
+      height: Math.round(height),
+    };
+    const fitted = deskDisplays().length > 1 ? fitBoundsToNearestDisplay(raw) : raw;
+    const cur = win.getContentBounds();
+    if (cur.x === fitted.x && cur.y === fitted.y && cur.width === fitted.width && cur.height === fitted.height) {
+      // 尺寸位置都没变：跳过，避免无意义的 DPI 重算
+    } else if (cur.width === fitted.width && cur.height === fitted.height) {
+      win.setPosition(fitted.x, fitted.y, false);
+    } else {
+      win.setContentBounds(fitted, false);
+    }
     // 碰撞站场：位置必须用**包围盒左上角**（renderer 显式上报 boxX/boxY）——
     // 窗口坐标 = 包围盒 − margin（半只宠物宽），直接拿窗口坐标会让跨窗检测整体错位
     const petId = [...windows.keys()].find((id) => windows.get(id) === win);
@@ -391,6 +464,12 @@ app.whenReady().then(() => {
     if (targetWin && !targetWin.isDestroyed()) {
       targetWin.webContents.send('pet:hit', { vx, vy });
     }
+  });
+
+  // 指针屏幕坐标：主进程 DIP（与 setContentBounds / display.bounds 同一套）。
+  // 渲染端 e.screenX 在跨 DPI 屏时会跳变，拖过屏缝就跟丢。
+  ipcMain.on('pet:get-cursor', (event) => {
+    event.returnValue = screen.getCursorScreenPoint();
   });
 
   // 点击穿透翻转：renderer 在光标进/出身体命中区时上报；穿透期间仍保留 forward（mousemove 继续转发）

--- a/dsh-pet/runtime/electron-helper/preload.js
+++ b/dsh-pet/runtime/electron-helper/preload.js
@@ -1,5 +1,6 @@
 // preload 桥：只暴露窗口控制原语——
 //   - setBounds：宠物窗口逐帧跟随（renderer 上报包围盒的屏幕坐标，主进程 setContentBounds）。
+//   - getCursorPoint：主进程 screen.getCursorScreenPoint（DIP，与 setContentBounds 同坐标系）。
 //     x/y/width/height = 窗口内容区坐标（用于移动窗口）；boxX/boxY = 宠物包围盒左上角
 //     （工作区坐标）——碰撞站场必须用包围盒坐标，不能用窗口坐标（窗口 = 包围盒 + 四周外扩 margin，
 //     差半只宠物宽，会让跨窗碰撞检测整体错位）。
@@ -17,6 +18,10 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('petBridge', {
   setBounds(x, y, width, height, boxX, boxY, size, bottomPad, vx, vy) {
     ipcRenderer.send('pet:set-bounds', { x, y, width, height, boxX, boxY, size, bottomPad, vx, vy });
+  },
+  // 与 setContentBounds 同一套 DIP；仅真实指针使用（冒烟派发的 PointerEvent 走 e.screenX）
+  getCursorPoint() {
+    return ipcRenderer.sendSync('pet:get-cursor');
   },
   setInteractive(interactive) {
     ipcRenderer.send('pet:set-interactive', !!interactive);

--- a/dsh-pet/runtime/electron-helper/sprite.js
+++ b/dsh-pet/runtime/electron-helper/sprite.js
@@ -36,6 +36,8 @@ class PetSprite {
     // 窗口 = sprite + 四边余量——气泡/未来弹窗显示在余量里；余量透明且点击穿透
     const m = this.size * WINDOW_MARGIN_RATIO;
     this.margin = { t: m, r: m, b: m, l: m };
+    this.spriteOff = { x: m, y: m };
+    this.winBox = null;
     window.__dshPetDebug.winMargin = this.margin;
     // 宠物包围盒左上角在【工作区】坐标系里的位置（本窗口的位置 = 宠物的位置）
     this.pos = { x: 0, y: 0 };
@@ -228,7 +230,34 @@ class PetSprite {
   // 才是屏幕坐标：单显示器主屏在原点时 VIEW.x/y=0，与旧行为逐位一致；左侧/上方有扩展屏
   // （原点非 0）时也不偏位（#43）。
   sendBounds(px, py) {
-    this.pos = { x: Math.round(px), y: Math.round(py) };
+    let petX = Math.round(px);
+    let petY = Math.round(py);
+    const desired = {
+      x: petX - this.margin.l + VIEW.x,
+      y: petY - this.margin.t + VIEW.y,
+      width: this.size + this.margin.l + this.margin.r,
+      height: this.winH + this.margin.t + this.margin.b,
+    };
+    // 多屏：HWND 整块落在中心所在屏，避免透明窗骑缝被 DWM 画成双屏分身。
+    // 窗口被挪开后必须改 sprite 偏移，宠物才仍停在逻辑坐标上（否则会瞬移/看起来像分身）。
+    const fitted = DISPLAYS.length > 1 && S.fitWindowToDisplay ? S.fitWindowToDisplay(desired, DISPLAYS) : desired;
+    let spriteX = petX + VIEW.x - fitted.x;
+    let spriteY = petY + VIEW.y - fitted.y;
+    const maxSX = fitted.width - this.size;
+    const maxSY = fitted.height - this.winH;
+    const clampX = Math.min(Math.max(spriteX, 0), Math.max(maxSX, 0));
+    const clampY = Math.min(Math.max(spriteY, 0), Math.max(maxSY, 0));
+    if (clampX !== spriteX || clampY !== spriteY) {
+      spriteX = clampX;
+      spriteY = clampY;
+      petX = Math.round(fitted.x + spriteX - VIEW.x);
+      petY = Math.round(fitted.y + spriteY - VIEW.y);
+    }
+    this.pos = { x: petX, y: petY };
+    this.spriteOff = { x: spriteX, y: spriteY };
+    this.winBox = fitted;
+    this.el.style.left = spriteX + 'px';
+    this.el.style.top = spriteY + 'px';
     window.__dshPetDebug.dragPos = { x: this.pos.x, y: this.pos.y };
     if (window.petBridge) {
       // 完整状态一次捎带：size/bottomPad 让静止宠物从首帧起就登记进碰撞站场
@@ -236,10 +265,10 @@ class PetSprite {
       // vx/vy 带当前速度——飞行中实时值、静止/拖拽 = 0，避免落地后残留上次飞行速度干扰碰撞动量。
       const fly = this.throwState;
       window.petBridge.setBounds(
-        this.pos.x - this.margin.l + VIEW.x,
-        this.pos.y - this.margin.t + VIEW.y,
-        this.size + this.margin.l + this.margin.r,
-        this.winH + this.margin.t + this.margin.b,
+        fitted.x,
+        fitted.y,
+        fitted.width,
+        fitted.height,
         this.pos.x, // 包围盒左上角（碰撞站场用：窗口坐标 ≠ 包围盒坐标）
         this.pos.y,
         this.size,
@@ -515,11 +544,25 @@ class PetSprite {
     this.throwState = null;
   }
 
-  /** 抛掷驱动：重力 + 边缘反弹 + 落地摩擦，落定后写入 customPos */
+  workAreas() {
+    return DISPLAYS.length && S.displayWorkArea
+      ? DISPLAYS.map(S.displayWorkArea)
+      : [{ x: VIEW.x, y: VIEW.y, width: VIEW.w, height: VIEW.h }];
+  }
+
+  /** 指针屏幕 DIP：真实手势走主进程 getCursorPoint（与 setContentBounds 同坐标系）；冒烟派发事件用 e.screenX */
+  pointerScreen(e) {
+    if (e && e.isTrusted && window.petBridge && typeof window.petBridge.getCursorPoint === 'function') {
+      const p = window.petBridge.getCursorPoint();
+      if (p && Number.isFinite(p.x) && Number.isFinite(p.y)) return p;
+    }
+    return { x: e.screenX, y: e.screenY };
+  }
+
+  /** 抛掷驱动：重力 + 当前屏工作区反弹；邻屏重叠边开口以便跨过，不再对外接矩形空洞弹跳 */
   startThrow(px, py, vx, vy) {
     this.stopDragFollow();
     this.stopMove();
-    const bounds = S.throwBounds({ W: VIEW.w, H: VIEW.h, size: this.size, sideAllow: this.sideAllow });
     const token = ++this.throwToken;
     let state = { x: px, y: py, vx, vy };
     let last = performance.now();
@@ -530,6 +573,20 @@ class PetSprite {
       const dt = (now - last) / 1000;
       last = now;
       const fallingVy = state.vy; // 本帧积分前的竖直速度（正=下落）：即落地冲击速度
+      const bounds =
+        (S.throwBoundsForPet &&
+          S.throwBoundsForPet({
+            displays: DISPLAYS,
+            originX: VIEW.x,
+            originY: VIEW.y,
+            size: this.size,
+            sideAllow: this.sideAllow,
+            petX: state.x,
+            petY: state.y,
+            halfW: this.halfW,
+            halfH: this.halfH,
+          })) ||
+        S.throwBounds({ W: VIEW.w, H: VIEW.h, size: this.size, sideAllow: this.sideAllow });
       const res = S.throwStep(state, dt, bounds, this.physics);
       state = { x: res.x, y: res.y, vx: res.vx, vy: res.vy };
       this.throwState = state;
@@ -570,6 +627,13 @@ class PetSprite {
         }
       }
       this.sendBounds(res.x, res.y);
+      if (this.pos.x !== state.x || this.pos.y !== state.y) {
+        if (this.pos.x !== state.x) state.vx = -state.vx * this.physics.restitution;
+        if (this.pos.y !== state.y) state.vy = -state.vy * this.physics.restitution;
+        state.x = this.pos.x;
+        state.y = this.pos.y;
+        this.throwState = state;
+      }
       // 落地 Q 弹：只在空中→地面转换帧触发一次，力度随冲击速度（轻落 0.8 ~ 重砸 0.55）
       const grounded = res.y >= bounds.maxY - 1;
       if (res.bounced && grounded && !prevGrounded) {
@@ -691,13 +755,14 @@ class PetSprite {
     } catch {
       /* 忽略捕获失败 */
     }
-    // 记录【按下时的指针屏幕坐标】与【按下时的宠物窗口位置】——之后全部用 e.screenX/Y
-    // 做增量：指针屏幕坐标与窗口位置无关，不受窗口被逐帧移动影响（window.screenX 会滞后/缓存）。
+    // 记录【按下时的指针屏幕 DIP】与【按下时的宠物视口位置】——之后用同一套 DIP 做增量。
+    // 真实手势走主进程光标（与 setContentBounds 同坐标系）；冒烟派发事件仍用 e.screenX。
+    const pointer = this.pointerScreen(e);
     this.dragState = {
       active: true,
       dragging: false,
-      sx: e.screenX,
-      sy: e.screenY,
+      sx: pointer.x,
+      sy: pointer.y,
       petX: this.pos.x,
       petY: this.pos.y,
     };
@@ -708,9 +773,10 @@ class PetSprite {
   onPointerMove(e) {
     const d = this.dragState;
     if (!d.active) return;
-    // 阈值判定用屏幕坐标增量（clientX 会随窗口移动而变化，屏幕坐标稳定）
-    const dx = e.screenX - d.sx;
-    const dy = e.screenY - d.sy;
+    // 阈值判定用屏幕 DIP 增量（clientX 会随窗口移动而变化；跨 DPI 屏不能直接信 e.screenX）
+    const pointer = this.pointerScreen(e);
+    const dx = pointer.x - d.sx;
+    const dy = pointer.y - d.sy;
     if (!d.dragging) {
       if (Math.hypot(dx, dy) < S.DRAG_THRESHOLD) return;
       d.dragging = true;
@@ -720,13 +786,26 @@ class PetSprite {
         this.playOnce(S.pick(this.animations.drag));
       }
     }
-    // 记录指针轨迹（screenX/Y 采样：与视口坐标只差常数偏移，速度一致；初速估算用）
+    // 记录指针轨迹（屏幕 DIP：与视口只差 VIEW 原点，速度一致；初速估算用）
     const now = performance.now();
-    this.dragTrail.push({ t: now, x: e.screenX, y: e.screenY });
+    this.dragTrail.push({ t: now, x: pointer.x, y: pointer.y });
     this.dragTrail = S.trimTrail(this.dragTrail, now);
-    // 弹簧目标 = 按下时的宠物位置 + 指针屏幕增量（窗口怎么动都不影响坐标）——不再硬贴指针，
-    // 由 rAF 弹簧跟随逐帧追赶（抹平高频抖动，与浏览器同构）
-    this.dragTarget = { x: d.petX + dx, y: d.petY + dy };
+    let tx = d.petX + dx;
+    let ty = d.petY + dy;
+    if (DISPLAYS.length > 1) {
+      const works = this.workAreas();
+      const sx = tx + this.halfW + VIEW.x;
+      const sy = ty + this.halfH + VIEW.y;
+      if (S.pointInRect && !works.some((w) => S.pointInRect(sx, sy, w))) {
+        const near = S.nearestRect(sx, sy, works);
+        if (near && S.clampPointToRect) {
+          const p = S.clampPointToRect(sx, sy, near);
+          tx += p.x - sx;
+          ty += p.y - sy;
+        }
+      }
+    }
+    this.dragTarget = { x: tx, y: ty };
     this.startDragFollow();
   }
 
@@ -744,14 +823,15 @@ class PetSprite {
         this.justDragged = false;
       }, 100);
       if (e && Number.isFinite(e.screenX)) {
+        const pointerUp = this.pointerScreen(e);
         // 原始输入留痕（实机排查用：验证指针屏幕坐标与窗口位移是否一致，如 DPI 缩放问题）
         window.__dshPetDebug.lastDragRaw = {
           petX: d.petX,
           petY: d.petY,
           sxDown: d.sx,
           syDown: d.sy,
-          xUp: e.screenX,
-          yUp: e.screenY,
+          xUp: pointerUp.x,
+          yUp: pointerUp.y,
         };
       }
       // 释放后接一段循环待机（与浏览器一致），再回随机链
@@ -816,10 +896,12 @@ class PetSprite {
     const r = this.hitRect;
     // forwarded 事件坐标以窗口为原点（与页坐标一致）；转换到 sprite 坐标需扣减窗口余量；
     // 异常时退回屏幕坐标 − 窗口屏幕位置推导（hitRect/pos 均为 sprite 坐标）
-    const wx = Number.isFinite(e.clientX) ? e.clientX : e.screenX - (this.pos.x + VIEW.x - this.margin.l);
-    const wy = Number.isFinite(e.clientY) ? e.clientY : e.screenY - (this.pos.y + VIEW.y - this.margin.t);
-    const px = wx - this.margin.l;
-    const py = wy - this.margin.t;
+    const offX = this.spriteOff ? this.spriteOff.x : this.margin.l;
+    const offY = this.spriteOff ? this.spriteOff.y : this.margin.t;
+    const wx = Number.isFinite(e.clientX) ? e.clientX : e.screenX - (this.pos.x + VIEW.x - offX);
+    const wy = Number.isFinite(e.clientY) ? e.clientY : e.screenY - (this.pos.y + VIEW.y - offY);
+    const px = wx - offX;
+    const py = wy - offY;
     this.setInteractive(px >= r.x && px <= r.x + r.w && py >= r.y && py <= r.y + r.h);
   }
 
@@ -847,12 +929,12 @@ class PetSprite {
   // 即可完整显示——**窗口和宠物零移动**，不存在跨进程位移竞态，也就不会瞬移闪帧。
   // 退化（可视区过小/窗口整体出屏，光标也点不到宠物）返回 null → 调用方按窗口视口兜底。
   visibleClampRect() {
-    // pos 是视口相对坐标，窗口屏幕位置 = pos + VIEW 原点 − 外扩余量（见 sendBounds）；
-    // 比较双方都用屏幕坐标（坐标系不混），返回的夹取矩形仍是窗口局部坐标
-    const winX = this.pos.x + VIEW.x - this.margin.l;
-    const winY = this.pos.y + VIEW.y - this.margin.t;
-    const winW = this.size + this.margin.l + this.margin.r;
-    const winH = this.winH + this.margin.t + this.margin.b;
+    // 用实际 HWND（sendBounds 裁切后）而不是「包围盒 − 余量」：多屏时窗口不再等于 pet+margin。
+    const fitted = this.winBox;
+    const winX = fitted ? fitted.x : this.pos.x + VIEW.x - this.margin.l;
+    const winY = fitted ? fitted.y : this.pos.y + VIEW.y - this.margin.t;
+    const winW = fitted ? fitted.width : this.size + this.margin.l + this.margin.r;
+    const winH = fitted ? fitted.height : this.winH + this.margin.t + this.margin.b;
     const vx0 = Math.max(VIEW.x, winX);
     const vy0 = Math.max(VIEW.y, winY);
     const vx1 = Math.min(VIEW.x + VIEW.w, winX + winW);

--- a/dsh-pet/src/shared/displays.test.ts
+++ b/dsh-pet/src/shared/displays.test.ts
@@ -1,0 +1,190 @@
+/**
+ * 多显示器几何单测 —— 复现「主屏 + 上移副屏」布局下的骑缝 / 空洞问题。
+ *
+ * 布局取自实机（WinForms Screen.Bounds，DIP）：
+ *   主屏  (0, 0, 2560, 1440)     work (0, 0, 2560, 1392)
+ *   副屏  (2560, -621, 1234, 2194) work (2560, -621, 1234, 2146)
+ * 外接矩形含主屏上方空洞；窗口若按外接矩形摆放会骑在 x=2560 上，两块屏同时合成。
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  canCrossWorkArea,
+  displayWorkArea,
+  fitWindowToDisplay,
+  nearestDisplay,
+  nearestRect,
+  parseDisplays,
+  throwBoundsForPet,
+  throwBoundsOnDisplay,
+  throwBoundsOpen,
+  type DisplayInfo,
+} from './displays.ts';
+
+const PRIMARY: DisplayInfo = {
+  x: 0,
+  y: 0,
+  width: 2560,
+  height: 1440,
+  workX: 0,
+  workY: 0,
+  workW: 2560,
+  workH: 1392,
+};
+const SECONDARY: DisplayInfo = {
+  x: 2560,
+  y: -621,
+  width: 1234,
+  height: 2194,
+  workX: 2560,
+  workY: -621,
+  workW: 1234,
+  workH: 2146,
+};
+const DISPLAYS = [PRIMARY, SECONDARY];
+const WORK = DISPLAYS.map(displayWorkArea);
+const ORIGIN = { x: 0, y: -621 };
+
+describe('parseDisplays', () => {
+  it('reads injected JSON and drops invalid rows', () => {
+    assert.deepEqual(parseDisplays(null), []);
+    assert.deepEqual(parseDisplays('nope'), []);
+    const list = parseDisplays(JSON.stringify([PRIMARY, { x: 'nope' }, SECONDARY]));
+    assert.equal(list.length, 2);
+    assert.equal(list[0].workW, 2560);
+    assert.equal(list[1].y, -621);
+  });
+});
+
+describe('nearestDisplay', () => {
+  it('hits the display that contains the point', () => {
+    assert.equal(nearestDisplay(100, 100, DISPLAYS), PRIMARY);
+    assert.equal(nearestDisplay(3000, -100, DISPLAYS), SECONDARY);
+  });
+
+  it('maps the void above the primary to the nearest real screen', () => {
+    const near = nearestRect(100, -300, WORK);
+    assert.ok(near);
+    assert.equal(near.x, 0);
+    assert.equal(near.y, 0);
+  });
+});
+
+describe('fitWindowToDisplay', () => {
+  it('pulls a straddling window fully onto the screen that owns its center', () => {
+    const fitted = fitWindowToDisplay({ x: 2400, y: 100, width: 924, height: 722 }, DISPLAYS);
+    assert.equal(fitted.x, 2560);
+    assert.equal(fitted.width, 924);
+    assert.ok(fitted.x + fitted.width <= SECONDARY.x + SECONDARY.width);
+    assert.ok(fitted.y >= SECONDARY.y);
+  });
+
+  it('does not move a window already inside the primary', () => {
+    const win = { x: 100, y: 200, width: 924, height: 722 };
+    assert.deepEqual(fitWindowToDisplay(win, DISPLAYS), win);
+  });
+});
+
+describe('canCrossWorkArea', () => {
+  it('allows crossing the shared bezel where the two work areas overlap in Y', () => {
+    assert.equal(canCrossWorkArea(WORK[0], WORK, 2500, 400, 'right'), true);
+    assert.equal(canCrossWorkArea(WORK[1], WORK, 2600, 400, 'left'), true);
+  });
+
+  it('blocks crossing into the void above the primary', () => {
+    assert.equal(canCrossWorkArea(WORK[1], WORK, 2600, -300, 'left'), false);
+  });
+});
+
+describe('throwBoundsOpen', () => {
+  it('opens the primary right edge and keeps the other three walls', () => {
+    const b = throwBoundsOpen({
+      current: WORK[0],
+      displays: WORK,
+      originX: ORIGIN.x,
+      originY: ORIGIN.y,
+      size: 462,
+      sideAllow: 80,
+      screenCX: 2400,
+      screenCY: 400,
+    });
+    assert.equal(b.maxX, Number.POSITIVE_INFINITY);
+    assert.ok(Number.isFinite(b.minX));
+    assert.ok(Number.isFinite(b.minY));
+    assert.ok(Number.isFinite(b.maxY));
+  });
+
+  it('keeps the secondary left wall when the pet is in the void-adjacent band', () => {
+    const b = throwBoundsOpen({
+      current: WORK[1],
+      displays: WORK,
+      originX: ORIGIN.x,
+      originY: ORIGIN.y,
+      size: 462,
+      sideAllow: 80,
+      screenCX: 2700,
+      screenCY: -300,
+    });
+    assert.ok(Number.isFinite(b.minX));
+    const closed = throwBoundsOnDisplay({
+      display: WORK[1],
+      originX: ORIGIN.x,
+      originY: ORIGIN.y,
+      size: 462,
+      sideAllow: 80,
+    });
+    assert.equal(b.minX, closed.minX);
+  });
+});
+
+describe('throwBoundsForPet', () => {
+  it('returns null on a single display so the caller keeps the AABB path', () => {
+    assert.equal(
+      throwBoundsForPet({
+        displays: [PRIMARY],
+        originX: 0,
+        originY: 0,
+        size: 462,
+        sideAllow: 80,
+        petX: 100,
+        petY: 100,
+        halfW: 231,
+        halfH: 130,
+      }),
+      null,
+    );
+  });
+
+  it('opens the bezel when the pet center is still on the primary', () => {
+    // screen (2400, 400) 在主屏工作区内，贴右缝
+    const b = throwBoundsForPet({
+      displays: DISPLAYS,
+      originX: ORIGIN.x,
+      originY: ORIGIN.y,
+      size: 462,
+      sideAllow: 80,
+      petX: 2400 - 231 - ORIGIN.x,
+      petY: 400 - 130 - ORIGIN.y,
+      halfW: 231,
+      halfH: 130,
+    });
+    assert.ok(b);
+    assert.equal(b.maxX, Number.POSITIVE_INFINITY);
+  });
+
+  it('walls the secondary left edge in the void-adjacent band', () => {
+    const b = throwBoundsForPet({
+      displays: DISPLAYS,
+      originX: ORIGIN.x,
+      originY: ORIGIN.y,
+      size: 462,
+      sideAllow: 80,
+      petX: 2700 - 231 - ORIGIN.x,
+      petY: -300 - 130 - ORIGIN.y,
+      halfW: 231,
+      halfH: 130,
+    });
+    assert.ok(b);
+    assert.ok(Number.isFinite(b.minX));
+  });
+});

--- a/dsh-pet/src/shared/displays.ts
+++ b/dsh-pet/src/shared/displays.ts
@@ -1,0 +1,247 @@
+// 多显示器几何：纯计算（无 Electron / DOM）。
+// 桌面 Helper 把 Electron screen 的 bounds + workArea 注入后，用这里的函数
+// 决定「窗口落在哪一块屏」以及「抛掷该对哪块屏的边反弹 / 何时允许跨屏」。
+//
+// 背景：把全部工作区收成一个外接矩形当视口，矩形里会有不属于任何屏幕的空洞
+// （副屏上移、竖屏并排等）。透明分层窗口一旦骑在屏缝上，Windows DWM 会在
+// 两块屏上同时合成同一窗口——拖过缝、副屏抛甩时就会跳变 / 分身闪烁。
+import type { ThrowBounds } from './physics';
+
+/** 轴对齐矩形（屏幕 DIP） */
+export interface DisplayRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * 一块物理屏：bounds 用于窗口落点（允许压到任务栏），
+ * work* 用于抛掷/漫游（宠物待在工作区内）。
+ */
+export interface DisplayInfo {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  workX: number;
+  workY: number;
+  workW: number;
+  workH: number;
+}
+
+export const displayBounds = (d: DisplayInfo): DisplayRect => ({
+  x: d.x,
+  y: d.y,
+  width: d.width,
+  height: d.height,
+});
+
+export const displayWorkArea = (d: DisplayInfo): DisplayRect => ({
+  x: d.workX,
+  y: d.workY,
+  width: d.workW,
+  height: d.workH,
+});
+
+export const sameRect = (a: DisplayRect, b: DisplayRect): boolean =>
+  a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+
+export const pointInRect = (x: number, y: number, r: DisplayRect): boolean =>
+  x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height;
+
+export const clampPointToRect = (x: number, y: number, r: DisplayRect): { x: number; y: number } => ({
+  x: Math.min(Math.max(x, r.x), r.x + Math.max(r.width, 1) - 1),
+  y: Math.min(Math.max(y, r.y), r.y + Math.max(r.height, 1) - 1),
+});
+
+/** 包含该点的矩形；不在任何矩形内则取距离最近的一块 */
+export const nearestRect = (x: number, y: number, rects: DisplayRect[]): DisplayRect | null => {
+  if (!rects.length) return null;
+  for (const r of rects) {
+    if (pointInRect(x, y, r)) return r;
+  }
+  let best = rects[0];
+  let bestDist = Infinity;
+  for (const r of rects) {
+    const c = clampPointToRect(x, y, r);
+    const dist = (c.x - x) * (c.x - x) + (c.y - y) * (c.y - y);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = r;
+    }
+  }
+  return best;
+};
+
+export const nearestDisplay = (x: number, y: number, displays: DisplayInfo[]): DisplayInfo | null => {
+  if (!displays.length) return null;
+  const hit = displays.find((d) => pointInRect(x, y, displayBounds(d)));
+  if (hit) return hit;
+  const near = nearestRect(x, y, displays.map(displayBounds));
+  return near ? displays.find((d) => sameRect(displayBounds(d), near)) || null : null;
+};
+
+/**
+ * 把窗口矩形收进「中心点所在屏」的 bounds，避免透明窗骑缝。
+ * 尺寸保持不变（窗口比该屏还大时只钉在该屏原点）。
+ */
+export const fitWindowToDisplay = (
+  win: { x: number; y: number; width: number; height: number },
+  displays: DisplayInfo[],
+): { x: number; y: number; width: number; height: number } => {
+  const cx = win.x + win.width / 2;
+  const cy = win.y + win.height / 2;
+  const d = nearestDisplay(cx, cy, displays);
+  if (!d) return win;
+  let { x, y } = win;
+  const { width, height } = win;
+  if (width <= d.width) {
+    if (x < d.x) x = d.x;
+    if (x + width > d.x + d.width) x = d.x + d.width - width;
+  } else {
+    x = d.x;
+  }
+  if (height <= d.height) {
+    if (y < d.y) y = d.y;
+    if (y + height > d.y + d.height) y = d.y + d.height - height;
+  } else {
+    y = d.y;
+  }
+  return { x, y, width, height };
+};
+
+export type CrossDir = 'left' | 'right' | 'up' | 'down';
+
+/**
+ * 沿当前工作区边缘外探 1px：那边若还有别的工作区，允许跨过去，否则当墙。
+ * 副屏上移时，缝外上半段探不到主屏——必须弹回，不能飞进外接矩形的空洞。
+ */
+export const canCrossWorkArea = (
+  current: DisplayRect,
+  displays: DisplayRect[],
+  screenCX: number,
+  screenCY: number,
+  dir: CrossDir,
+): boolean => {
+  let px = screenCX;
+  let py = screenCY;
+  if (dir === 'left') px = current.x - 1;
+  else if (dir === 'right') px = current.x + current.width;
+  else if (dir === 'up') py = current.y - 1;
+  else py = current.y + current.height;
+  return displays.some((d) => !sameRect(d, current) && pointInRect(px, py, d));
+};
+
+/** 当前工作区 → 视口坐标下的抛掷边界（不含跨屏开口） */
+export const throwBoundsOnDisplay = (o: {
+  display: DisplayRect;
+  originX: number;
+  originY: number;
+  size: number;
+  sideAllow: number;
+}): ThrowBounds => {
+  const h = (o.size * 9) / 16;
+  const ox = o.display.x - o.originX;
+  const oy = o.display.y - o.originY;
+  return {
+    minX: ox - o.sideAllow,
+    minY: oy,
+    maxX: ox + o.display.width - o.size + o.sideAllow,
+    maxY: oy + o.display.height - h,
+  };
+};
+
+/** 当前工作区抛掷边界：与邻屏重叠的边开口，其余边照常夹取反弹 */
+export const throwBoundsOpen = (o: {
+  current: DisplayRect;
+  displays: DisplayRect[];
+  originX: number;
+  originY: number;
+  size: number;
+  sideAllow: number;
+  screenCX: number;
+  screenCY: number;
+}): ThrowBounds => {
+  const b = throwBoundsOnDisplay({
+    display: o.current,
+    originX: o.originX,
+    originY: o.originY,
+    size: o.size,
+    sideAllow: o.sideAllow,
+  });
+  if (canCrossWorkArea(o.current, o.displays, o.screenCX, o.screenCY, 'left')) b.minX = Number.NEGATIVE_INFINITY;
+  if (canCrossWorkArea(o.current, o.displays, o.screenCX, o.screenCY, 'right')) b.maxX = Number.POSITIVE_INFINITY;
+  if (canCrossWorkArea(o.current, o.displays, o.screenCX, o.screenCY, 'up')) b.minY = Number.NEGATIVE_INFINITY;
+  if (canCrossWorkArea(o.current, o.displays, o.screenCX, o.screenCY, 'down')) b.maxY = Number.POSITIVE_INFINITY;
+  return b;
+};
+
+/**
+ * 主进程注入的显示器列表（屏幕 DIP）。非法/空 → []，调用方回落单屏旧路径。
+ */
+export const parseDisplays = (raw: string | null | undefined): DisplayInfo[] => {
+  let list: unknown = [];
+  try {
+    list = JSON.parse(raw || '[]');
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(list)) return [];
+  const out: DisplayInfo[] = [];
+  for (const item of list) {
+    if (!item || typeof item !== 'object') continue;
+    const rec = item as Record<string, unknown>;
+    const x = Number(rec.x);
+    const y = Number(rec.y);
+    const width = Number(rec.width);
+    const height = Number(rec.height);
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) continue;
+    const workX = Number(rec.workX);
+    const workY = Number(rec.workY);
+    const workW = Number(rec.workW);
+    const workH = Number(rec.workH);
+    out.push({
+      x,
+      y,
+      width,
+      height,
+      workX: Number.isFinite(workX) ? workX : x,
+      workY: Number.isFinite(workY) ? workY : y,
+      workW: Number.isFinite(workW) && workW > 0 ? workW : width,
+      workH: Number.isFinite(workH) && workH > 0 ? workH : height,
+    });
+  }
+  return out;
+};
+
+/** 视口相对坐标下、当前宠物中心所在工作区的抛掷边界；单屏/未知返回 null（调用方用外接矩形）。 */
+export const throwBoundsForPet = (o: {
+  displays: DisplayInfo[];
+  originX: number;
+  originY: number;
+  size: number;
+  sideAllow: number;
+  petX: number;
+  petY: number;
+  halfW: number;
+  halfH: number;
+}): ThrowBounds | null => {
+  if (o.displays.length <= 1) return null;
+  const works = o.displays.map(displayWorkArea);
+  const screenCX = o.petX + o.halfW + o.originX;
+  const screenCY = o.petY + o.halfH + o.originY;
+  const current = nearestRect(screenCX, screenCY, works);
+  if (!current) return null;
+  return throwBoundsOpen({
+    current,
+    displays: works,
+    originX: o.originX,
+    originY: o.originY,
+    size: o.size,
+    sideAllow: o.sideAllow,
+    screenCX,
+    screenCY,
+  });
+};
+

--- a/dsh-pet/src/shared/index.ts
+++ b/dsh-pet/src/shared/index.ts
@@ -17,6 +17,7 @@ export * from './notify';
 export * from './menu'; // 统一右键菜单（本目录唯一的 DOM 例外：树=纯函数，渲染=两端共用同一份）
 export * from './chat'; // 对话弹窗（menu 之后第二个 DOM 例外：数据=纯函数，弹窗=两端共用同一份）
 export * from './physics'; // 拖拽抛掷物理（弹簧跟手 + 甩抛 + 重力反弹）
+export * from './displays'; // 多显示器几何（窗口落单屏 / 抛掷按真实工作区反弹）
 export * from './score'; // 点击积分（速度/大小 → 分数，纯逻辑）
 export * from './score-popup'; // 点击积分弹窗 + 粒子爆发（menu/chat 之后第三个 DOM 例外：渲染=两端共用同一份）
 export * from './work-status'; // 工作状态联动（DSH 会话事件 → 档位动画/气泡：档位常量 + reducer + 文案，浏览器消费）


### PR DESCRIPTION
和 #44 遇到类似的情况，电脑外接4K双屏（主屏横向，副屏纵向，呈现右倒T字型布局）使用时，大肥鱼在拖过屏幕交界处时会产生定位错误：位置会出现跳跃瞬移并闪烁。抛甩也一样，在副屏抛甩时更明显——大肥鱼会不停地在主屏和副屏之间分身闪烁。

## Summary
- 桌面透明窗不再骑在显示器缝上：窗口始终整块落在中心所在屏的 bounds 内，避免 Windows DWM 在两块屏同时合成导致拖过缝 / 副屏抛甩时跳跃、分身闪烁。
- 抛掷按真实工作区反弹：外接矩形里的空洞当墙，只有与邻屏重叠的边才允许换屏。
- 拖拽跟手改用主进程 DIP 光标，跨屏时不再被窗口坐标和 `screenX` 混用带偏。
- 几何计算抽到 `src/shared/displays.ts`，并补了单测。

## Test plan
- [ ] 双屏（含不同 DPI / 副屏上移或左右拼接）下，拖拽宠物穿过屏缝：位置连续，无跳跃闪烁
- [ ] 在副屏抛甩宠物：只出现一只，不会在两块屏同时分身闪烁
- [ ] 单屏行为与修复前一致（漫游 / 抛掷 / 角落定位）
- [ ] `dsh-pet` 包内 `displays` 单测通过
