### PR TITLE
fix(desktop): 多屏异构 DPI——统一设备缩放消除跨屏闪烁，边界改用工作区并集

### DIFF
--- a/dsh-pet/package.json
+++ b/dsh-pet/package.json
@@ -70,7 +70,7 @@
     "dev:mock": "node scripts/dev/mock-server.mjs",
     "prepack": "npm run types && npm run typecheck && npm run lint && npm run format:check && node scripts/prepack-check.js",
     "prepare": "node scripts/prepare.js",
-    "test": "node --experimental-strip-types --test src/**/*.test.ts",
+    "test": "node --experimental-strip-types --import ./scripts/test-register.mjs --test src/**/*.test.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "types": "node scripts/gen-types.mjs",
     "lint": "eslint .",

--- a/dsh-pet/runtime/electron-helper/constants.js
+++ b/dsh-pet/runtime/electron-helper/constants.js
@@ -17,17 +17,55 @@ const CONFIG = {
 // bridge 模式（DSH_PET_BRIDGE=1）：请求走自定义 scheme，经 Electron 主进程转宿主管道——
 // 绕开 DSH Desktop 2.0.3+ 的浏览器访问闸门（只放行带令牌的请求，插件自拉进程的裸 HTTP 全 403）
 const BRIDGE = params.get('bridge') === '1';
-// 视口 = 全部显示器工作区的外接矩形（多显示器时即整个桌面；窗口只是宠物的一块局部画布）：
-// 漫游边界/角落定位/抛掷反弹/位置比例换算都用它——宠物可以跨屏漫游、被甩到其它显示器（#43）；
-// 单显示器时它即主屏工作区，行为与以前完全一致。
+// 视口 = 全部显示器工作区的外接矩形（多显示器时即整个桌面；窗口只是宠物的一块局部画布）。
+// 它只是**坐标系原点与比例换算基准**：位置比例（customPos）、漫游 ratio 都按它算。
 // x/y = 外接矩形左上角（多显示器时原点非 0）——visibleClampRect 计算「窗口 ∩ 工作区」需要它；
 // 缺省 0（单显示器原点即 0）。注意：缺失会令夹取矩形变 NaN，菜单将飞到窗口左上角（#41 回归）。
+//
+// **边界判定一律不用它**，改用下面 AREAS 的并集：显示器摆放不规则时外接矩形里有大片空洞
+// （实测右倒 T 型双屏 23.7% 的面积不属于任何屏），拿它当边界会让宠物走进/飞进不可见区域。
+// 字段可变：显示器分辨率/缩放变化、插拔屏、旋转时由 applyDeskGeometry 就地重挂（#P4）。
 const VIEW = {
   x: Number(params.get('workAreaX') || 0),
   y: Number(params.get('workAreaY') || 0),
   w: Number(params.get('workAreaW') || (window.screen && window.screen.availWidth) || 1920),
   h: Number(params.get('workAreaH') || (window.screen && window.screen.availHeight) || 1080),
 };
+/** 逐显示器工作区，**视口相对坐标**（= 屏幕坐标 − VIEW 原点）。抛掷/漫游/菜单夹取都走它们的并集 */
+let AREAS = [];
+/** 主屏工作区（视口相对坐标）：角落定位与「回到初始位置」用它——外接矩形的角落可能落在空洞里 */
+let PRIMARY_AREA = null;
+
+/** 把主进程给的桌面几何（{hull, areas, primaryIndex}，屏幕坐标）挂到 VIEW / AREAS / PRIMARY_AREA */
+function applyDeskGeometry(geo) {
+  const hull = geo && geo.hull;
+  const list = geo && Array.isArray(geo.areas) ? geo.areas.filter((a) => a && a.width > 0 && a.height > 0) : [];
+  if (!hull || !(hull.width > 0) || !(hull.height > 0) || list.length === 0) return false;
+  VIEW.x = hull.x;
+  VIEW.y = hull.y;
+  VIEW.w = hull.width;
+  VIEW.h = hull.height;
+  AREAS = S.translateRects(list, -hull.x, -hull.y);
+  const pi = Number(geo.primaryIndex);
+  PRIMARY_AREA = AREAS[Number.isInteger(pi) && pi >= 0 && pi < AREAS.length ? pi : 0];
+  return true;
+}
+
+// 首帧几何走 URL query（position() 定角落时就要用）；运行期变化再经 pet:displays 推送。
+// areas 缺失（手动 start-desktop / 老版本主进程）时退化为「整个视口就是一块屏」= 旧行为。
+applyDeskGeometry({
+  hull: { x: VIEW.x, y: VIEW.y, width: VIEW.w, height: VIEW.h },
+  areas: (() => {
+    try {
+      const parsed = JSON.parse(params.get('areas') || '[]');
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    } catch {
+      /* 落到下面的单矩形兜底 */
+    }
+    return [{ x: VIEW.x, y: VIEW.y, width: VIEW.w, height: VIEW.h }];
+  })(),
+  primaryIndex: Number(params.get('primaryIndex') || 0),
+});
 const ORIGIN = new URL(CONFIG.configUrl).origin;
 /** 宿主 /dsh-pet-7340 前缀：bridge 走自定义 scheme（主进程转发），否则 HTTP 直连宿主 */
 const BASE = BRIDGE ? 'dsh-pet-bridge://dsh-pet/dsh-pet-7340' : ORIGIN + '/dsh-pet-7340';

--- a/dsh-pet/runtime/electron-helper/main.js
+++ b/dsh-pet/runtime/electron-helper/main.js
@@ -21,11 +21,22 @@
  */
 const { app, BrowserWindow, ipcMain, screen, shell, protocol } = require('electron');
 const path = require('node:path');
-const { writeFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+const { readFileSync, writeFileSync } = require('node:fs');
 const fsPromises = require('node:fs/promises');
 
 // 允许无用户手势直接播放（余额动画等）
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+
+// 显式定名：Helper 是被 `electron.exe <main.js>` 直接拉起的，Electron 取不到 app 名会回落成
+// "Electron"，userData 便落到 %APPDATA%\Electron —— 那是所有这么跑的 Electron 脚本的公共目录，
+// 我们的 DPI 缓存与 Chromium profile 都会和别人混在一起。必须赶在任何 getPath('userData') 之前设。
+app.setName('dsh-pet-electron-helper');
+
+/** DPI 探测子进程模式：不建窗口，只把主屏 scaleFactor 打到 stdout 就退出（见 probePrimaryScale） */
+const DPI_PROBE = process.env.DSH_PET_DPI_PROBE === '1';
+/** 探测进程的输出标记（父进程按它抓值） */
+const DPI_MARK = 'dsh-pet-primary-scale:';
 
 // Windows 透明分层窗口（WS_EX_LAYERED）在 DWM 硬件加速合成下存在多处缺陷：
 //   - 拖拽移动时窗口四周出现黑色边框（#37）
@@ -34,6 +45,129 @@ app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
 // 不影响浏览器形态与主 DSH（独立进程）；非 Windows（macOS/Linux）合成路径不同，保留硬件加速。
 if (process.platform === 'win32') {
   app.disableHardwareAcceleration();
+}
+
+// ---------- 全局 DPI 线性化（多显示器异构缩放的根因修复） ----------
+//
+// Windows 上 Chromium 的 DIP↔物理 换算是**逐显示器**的仿射变换，而且
+// ScreenWin::DIPToScreenRect(hwnd, rect) 用的是「hwnd 当前归属屏」的那一组参数：
+//   physical = (dip − D.dipOrigin) × D.scale + D.pixelOrigin
+// 归属由 MonitorFromWindow(MONITOR_DEFAULTTONEAREST) 按面积占比决定，窗口骑缝时会反复翻转。
+// 两屏缩放不同时，同一个 DIP 值在翻转前后落到不同物理位置、算出不同物理尺寸
+// （实测 1.5/1.75 双屏：位置差 110px、924 DIP 宽的窗口尺寸差 231px），
+// 于是 setContentBounds 每帧的落点在两套坐标系之间横跳 —— 这就是拖过屏缝时的「分身闪烁」，
+// 也是两屏缩放一致时同样骑缝却毫无问题的原因。
+//
+// --force-device-scale-factor 让 Chromium 的 GetMonitorScaleFactors() 对所有显示器
+// 直接返回同一个值，全部屏塌缩成**同一个**仿射变换 ⇒ DIPToScreenRect 的结果与窗口归属无关。
+//
+// 取值必须是 **1**，不能取主屏的 scaleFactor。实测（tools/probe-dpi.cjs，1.5 + 1.75 双屏）：
+//   forced=1.5 → display.bounds 被二次缩放（主屏物理 3840 宽报成 1706 = 3840/1.5/1.5，
+//                而同一块屏的 workArea 报 2560 = 3840/1.5，两者自相矛盾）。
+//                DIPToScreenPoint 用 bounds.origin() 当 dipOrigin，于是
+//                pixelOrigin(3840) ≠ dipOrigin(1706)×1.5，副屏多出 1281px 的**恒定**偏移——
+//                比不加 switch 时的 75px 还糟。
+//   forced=1   → bounds 与 workArea 一致，每块屏都满足 pixelOrigin == dipOrigin×scale，
+//                DIP 与物理像素成为恒等映射，探针的 DELTA 全 0（尺寸差 231×151 也一并归零）。
+// 所以这里锁死 1：坐标系 = Windows 物理像素，跨屏几何再无换算与舍入。
+//
+// 代价：宠物尺寸的单位从 DIP 变成物理像素，不补偿的话在 150% 的屏上会小 1/1.5。
+// 用探测到的**真实主屏 scaleFactor** 乘进渲染端的 CONFIG.scale 抵掉（见 petScale()）——
+// 主屏上的观感与修复前逐像素相同；其余屏改按主屏缩放渲染宠物（同尺寸同分辨率的两块屏上
+// 物理大小反而一致了）。探测失败就整个不启用，退回修复前行为，不做没有补偿的缩放。
+//
+// 环境变量 DSH_PET_FORCE_DSF：'0' = 关闭本机制；其它正数 = 强制该值（排障用，会踩上面的 bug）。
+//
+// 取值时机是个麻烦：switch 必须在 app ready 之前设，而那时 screen 模块还不可用。
+// 所以首次启动 spawn 一个自己的探测子进程（DSH_PET_DPI_PROBE=1，只打印 scaleFactor 就退出，
+// ~0.5s）并把结果落盘；之后每次启动直接读缓存，零开销。
+
+/** 主屏缩放缓存文件（userData 在 ready 前即可用） */
+function dpiCacheFile() {
+  return path.join(app.getPath('userData'), 'primary-scale.json');
+}
+
+function readCachedPrimaryScale() {
+  try {
+    const v = Number(JSON.parse(readFileSync(dpiCacheFile(), 'utf8')).scaleFactor);
+    return Number.isFinite(v) && v > 0 ? v : 0;
+  } catch {
+    return 0; // 首次启动/文件损坏：当作无缓存，重新探测
+  }
+}
+
+function writeCachedPrimaryScale(value) {
+  try {
+    writeFileSync(dpiCacheFile(), JSON.stringify({ scaleFactor: value }), 'utf8');
+  } catch (e) {
+    console.error('[dsh-pet-desktop-helper] write dpi cache failed:', String(e && e.message ? e.message : e));
+  }
+}
+
+/** 从探测子进程的输出里抓 scaleFactor（0 = 没抓到） */
+function parseProbeOutput(text) {
+  const m = new RegExp(DPI_MARK + '([0-9.]+)').exec(String(text || ''));
+  const v = m ? Number(m[1]) : 0;
+  return Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+/** 拉起探测子进程读主屏 scaleFactor（同一个 electron + 同一个 main.js，走 DPI_PROBE 分支） */
+function probePrimaryScale() {
+  const opts = {
+    env: { ...process.env, DSH_PET_DPI_PROBE: '1', DSH_PET_BRIDGE: '0', DSH_PET_SMOKE: '0' },
+    timeout: 20000,
+    encoding: 'utf8',
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+  let out = '';
+  try {
+    out = execFileSync(process.execPath, [__filename, '--dsh-pet-dpi-probe'], opts);
+  } catch (e) {
+    // 只认 stdout，不认退出码：一个不开窗口的 Electron 进程调 app.exit() 在 Windows 上
+    // 偶发 0xC0000005（退出期访问违例），但那时值早就写出来了，丢掉它纯属浪费一次冷启动。
+    out = e && e.stdout ? String(e.stdout) : '';
+    if (!parseProbeOutput(out)) {
+      const detail = [
+        e && e.status !== undefined ? 'status=' + e.status : '',
+        e && e.stderr ? 'stderr=' + String(e.stderr).trim().slice(0, 300) : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      console.error(
+        '[dsh-pet-desktop-helper] dpi probe failed:',
+        String(e && e.message ? e.message : e).split('\n')[0],
+        detail,
+      );
+      return 0; // 探测失败：不加 switch，退回修复前行为（多屏异构 DPI 会闪，但不影响可用性）
+    }
+  }
+  const v = parseProbeOutput(out);
+  if (v > 0) writeCachedPrimaryScale(v);
+  return v;
+}
+
+/** 真实主屏 scaleFactor（探测所得；0 = 未知）。开启线性化后 screen API 只会报 1，只能靠它。 */
+let PRIMARY_SCALE = 0;
+/** 实际生效的强制缩放（0 = 未启用，坐标系维持修复前的逐屏 DIP） */
+let FORCED_SCALE = 0;
+if (!DPI_PROBE && process.env.DSH_PET_FORCE_DSF !== '0') {
+  PRIMARY_SCALE = readCachedPrimaryScale() || probePrimaryScale();
+  const override = Number(process.env.DSH_PET_FORCE_DSF);
+  const forced = Number.isFinite(override) && override > 0 ? override : PRIMARY_SCALE > 0 ? 1 : 0;
+  if (forced > 0) {
+    app.commandLine.appendSwitch('force-device-scale-factor', String(forced));
+    FORCED_SCALE = forced;
+  }
+}
+
+/**
+ * 渲染端的 CONFIG.scale：宿主给的基准 × 物理像素补偿。
+ * 线性化开启后 1 逻辑像素 = 1 物理像素，宠物按主屏缩放放大回原来的观感。
+ */
+function petScale() {
+  const base = Number(process.env.DSH_PET_SCALE || '1') || 1;
+  return FORCED_SCALE > 0 && PRIMARY_SCALE > 0 ? base * (PRIMARY_SCALE / FORCED_SCALE) : base;
 }
 
 /** bridge 模式：DSH_PET_BRIDGE=1（宿主注入）。开启时注册 dsh-pet-bridge scheme + 管道转发 */
@@ -61,6 +195,9 @@ if (BRIDGE) {
 
 /** 窗口表：petId -> BrowserWindow */
 const windows = new Map();
+
+/** win.id -> 上一次**请求**的内容区矩形（"x,y,w,h"）：pet:set-bounds 的去重基准，见那里的注释 */
+const lastRequestedBounds = new Map();
 
 /**
  * 宠物间碰撞 broker 状态：petId -> { x, y, vx, vy, size, bottomPad }。
@@ -127,31 +264,48 @@ function petWindowSize(size) {
 }
 
 /**
- * 全部显示器工作区的外接矩形（"整个桌面"的可用区域并集）。
- * 注入给渲染端作为视口 VIEW —— 多显示器时漫游/抛掷/角落定位/菜单夹取全部跨屏
- * （#43：宠物可以被甩/拖到其它显示器）；单显示器时它就是主屏工作区，行为与以前完全一致。
+ * 桌面几何：**逐显示器的工作区列表** + 它们的外接矩形 + 主屏下标。
+ *
+ * 外接矩形（hull）仍然是渲染端视口 VIEW 的来源——它只用作坐标系原点与比例换算基准。
+ * 但所有边界判定（漫游落点 / 抛掷反弹 / 角落定位 / 菜单夹取）必须走 areas 的**并集**：
+ * 显示器摆放不规则时 hull 里会有大片不属于任何屏的空洞，以 hull 为边界会把宠物放进去
+ * （实测右倒 T 型双屏：hull 的 23.7% 是空洞，宠物飞进去就彻底看不见了）。
  */
-function deskWorkArea() {
+function deskGeometry() {
+  const displays = screen.getAllDisplays();
+  const areas = displays.map((d) => ({
+    x: d.workArea.x,
+    y: d.workArea.y,
+    width: d.workArea.width,
+    height: d.workArea.height,
+  }));
   let x0 = Infinity;
   let y0 = Infinity;
   let x1 = -Infinity;
   let y1 = -Infinity;
-  for (const d of screen.getAllDisplays()) {
-    const a = d.workArea;
+  for (const a of areas) {
     x0 = Math.min(x0, a.x);
     y0 = Math.min(y0, a.y);
     x1 = Math.max(x1, a.x + a.width);
     y1 = Math.max(y1, a.y + a.height);
   }
-  return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
+  const primaryId = screen.getPrimaryDisplay().id;
+  const primaryIndex = Math.max(
+    0,
+    displays.findIndex((d) => d.id === primaryId),
+  );
+  return { hull: { x: x0, y: y0, width: x1 - x0, height: y1 - y0 }, areas, primaryIndex };
 }
 
 function createPetWindows() {
-  const area = deskWorkArea();
+  const geo = deskGeometry();
+  const area = geo.hull;
   const configUrl = process.env.DSH_PET_CONFIG_URL || 'http://127.0.0.1:3080/dsh-pet-7340/config';
   const pets = petsFromEnv();
+  const scale = petScale();
   for (const pet of pets) {
-    const { width, height } = petWindowSize(pet.size);
+    // 初始窗口尺寸也要吃缩放补偿，否则启动瞬间会有一次可见的尺寸跳变
+    const { width, height } = petWindowSize(pet.size * scale);
     const win = new BrowserWindow({
       width,
       height,
@@ -190,18 +344,25 @@ function createPetWindows() {
     win.setIgnoreMouseEvents(true, { forward: true });
     windowIgnore.set(win.id, true);
     win.once('ready-to-show', () => win.show());
-    win.on('closed', () => windows.delete(pet.id));
+    win.on('closed', () => {
+      windows.delete(pet.id);
+      lastRequestedBounds.delete(win.id);
+    });
     win
       .loadFile('index.html', {
         query: {
           configUrl,
           bridge: BRIDGE ? '1' : '0',
-          scale: process.env.DSH_PET_SCALE || '1',
+          scale: String(scale),
           petIndex: String(pet.index),
           workAreaW: String(area.width),
           workAreaH: String(area.height),
           workAreaX: String(area.x),
           workAreaY: String(area.y),
+          // 逐屏工作区（屏幕坐标）+ 主屏下标：渲染端所有边界判定走它们的并集，不走外接矩形。
+          // 首帧就要用（position() 定角落），所以走 query；运行期变化再经 pet:displays 推送。
+          areas: JSON.stringify(geo.areas),
+          primaryIndex: String(geo.primaryIndex),
         },
       })
       .catch((error) => {
@@ -311,6 +472,24 @@ async function handleBridgeRequest(request) {
 }
 
 app.whenReady().then(() => {
+  // 探测子进程：此时没有 force-device-scale-factor，读到的是 Windows 的真实主屏缩放。
+  // 退出推迟一拍——在 ready 回调里直接 app.exit() 会赶在 stdout 落盘前拆掉进程
+  if (DPI_PROBE) {
+    process.stdout.write(DPI_MARK + screen.getPrimaryDisplay().scaleFactor + '\n');
+    setTimeout(() => app.exit(0), 0);
+    return;
+  }
+  console.error(
+    '[dsh-pet-desktop-helper] displays: ' +
+      JSON.stringify(deskGeometry()) +
+      ' forcedScaleFactor=' +
+      (FORCED_SCALE || 'off') +
+      ' primaryScale=' +
+      (PRIMARY_SCALE || 'unknown') +
+      ' petScale=' +
+      petScale(),
+  );
+
   if (BRIDGE) {
     // 自定义 scheme 接住渲染端全部请求（配置/余额/碎碎念/广播/素材）
     protocol.handle('dsh-pet-bridge', (request) =>
@@ -336,10 +515,15 @@ app.whenReady().then(() => {
     const width = Number(bounds?.width);
     const height = Number(bounds?.height);
     if (![x, y, width, height].every(Number.isFinite)) return;
-    win.setContentBounds(
-      { x: Math.round(x), y: Math.round(y), width: Math.round(width), height: Math.round(height) },
-      false,
-    );
+    // 去重必须比较**我们上一次请求的值**，绝不能拿 win.getContentBounds() 回读值来比：
+    // 跨缩放屏的 DIP↔物理 往返有 ScaleToEnclosingRect（向外取整）与 origin 舍入，
+    // 读回值与设定值永远不相等，去重永远不生效，反而变成每帧强制重设窗口位置。
+    const rect = { x: Math.round(x), y: Math.round(y), width: Math.round(width), height: Math.round(height) };
+    const key = rect.x + ',' + rect.y + ',' + rect.width + ',' + rect.height;
+    if (lastRequestedBounds.get(win.id) !== key) {
+      lastRequestedBounds.set(win.id, key);
+      win.setContentBounds(rect, false);
+    }
     // 碰撞站场：位置必须用**包围盒左上角**（renderer 显式上报 boxX/boxY）——
     // 窗口坐标 = 包围盒 − margin（半只宠物宽），直接拿窗口坐标会让跨窗检测整体错位
     const petId = [...windows.keys()].find((id) => windows.get(id) === win);
@@ -411,6 +595,46 @@ app.whenReady().then(() => {
       console.error('[dsh-pet-desktop-helper] openExternal failed:', error);
     });
   });
+
+  // 显示器热更新：分辨率/缩放变化、插拔屏、旋转都会让桌面几何失效。原先几何只在
+  // createPetWindows() 算一次并经 URL query 注入，渲染端 VIEW 是模块顶层常量，运行期永不更新——
+  // 表现为「改了分辨率后可移动范围还是旧的」。这里重算并推给所有窗口，渲染端就地重挂。
+  let displaysTimer = null;
+  const pushDisplays = () => {
+    const geo = deskGeometry();
+    lastRequestedBounds.clear(); // 坐标系变了，去重缓存作废，下一帧必须真的重设一次
+    for (const win of windows.values()) {
+      if (!win.isDestroyed()) win.webContents.send('pet:displays', geo);
+    }
+    console.error('[dsh-pet-desktop-helper] displays changed: ' + JSON.stringify(geo));
+    // 主屏缩放可能一起变了（它决定宠物的尺寸补偿）。线性化生效期间 screen API 只报被强制的值，
+    // 真实值只能靠探测子进程拿；不一致就刷新缓存，下次启动自动用上。
+    if (FORCED_SCALE > 0) {
+      setTimeout(() => {
+        const real = probePrimaryScale();
+        if (real > 0 && Math.abs(real - PRIMARY_SCALE) > 1e-6) {
+          console.error(
+            '[dsh-pet-desktop-helper] primary scaleFactor changed ' +
+              PRIMARY_SCALE +
+              ' -> ' +
+              real +
+              '; restart the desktop pet to resize',
+          );
+        }
+      }, 1000).unref?.();
+    }
+  };
+  /** 显示器事件会连发（一次改动能来好几条），去抖后只重算一次 */
+  const scheduleDisplays = () => {
+    if (displaysTimer) clearTimeout(displaysTimer);
+    displaysTimer = setTimeout(() => {
+      displaysTimer = null;
+      pushDisplays();
+    }, 300);
+  };
+  screen.on('display-metrics-changed', scheduleDisplays);
+  screen.on('display-added', scheduleDisplays);
+  screen.on('display-removed', scheduleDisplays);
 
   // 冒烟自检模式（默认关闭）：DSH_PET_SMOKE=1 时延时截图到 DSH_PET_SMOKE_OUT 后退出，
   // 用于验证窗口/渲染/动画链路（如 CI 或本地验证）。

--- a/dsh-pet/runtime/electron-helper/preload.js
+++ b/dsh-pet/runtime/electron-helper/preload.js
@@ -38,4 +38,9 @@ contextBridge.exposeInMainWorld('petBridge', {
   onPetHit(cb) {
     ipcRenderer.on('pet:hit', (e, payload) => cb(payload));
   },
+  // 显示器热更新：分辨率/缩放变化、插拔屏、旋转后主进程重算桌面几何并推来
+  // （{hull, areas, primaryIndex}，屏幕坐标）——渲染端就地重挂视口与边界。
+  onDisplays(cb) {
+    ipcRenderer.on('pet:displays', (e, geo) => cb(geo));
+  },
 });

--- a/dsh-pet/runtime/electron-helper/renderer.js
+++ b/dsh-pet/runtime/electron-helper/renderer.js
@@ -111,10 +111,24 @@ function injectAssets() {
   document.head.appendChild(menuStyle);
 }
 
-// 工作区尺寸由主进程注入并在进程生命周期内不变；窗口本身跟随宠物移动，
-// 这里仍兜底处理窗口内容区尺寸异常的情况（按当前窗口位置重新规整）。
+// 显示器几何变化（改分辨率/缩放、插拔屏、旋转）：主进程重算后推来，渲染端就地重挂视口与边界。
+// 这条通道是必需的——桌面几何原先只在窗口创建时经 URL query 注入一次，运行期永不更新。
+if (window.petBridge && window.petBridge.onDisplays) {
+  window.petBridge.onDisplays((geo) => {
+    if (!applyDeskGeometry(geo)) return;
+    for (const s of sprites) s.relayout();
+  });
+}
+
+// 窗口内容区尺寸异常时按当前位置重新规整。
+// 守卫：拖拽/飞行/漫游中**绝不**重设位置——这三种状态下位置由输入或物理驱动，而 position()
+// 会把宠物拉回 customPos（上一次的落点）。跨屏时 Windows 会因 WM_DPICHANGED 主动改窗口尺寸，
+// 那正好落在拖拽/飞行过程中，不设防就会看到宠物瞬间跳回上一个落点。
 window.addEventListener('resize', () => {
-  for (const s of sprites) s.position();
+  for (const s of sprites) {
+    if (s.dragState.active || s.throwRef !== null || s.moveRef !== null) continue;
+    s.position();
+  }
 });
 
 injectAssets();

--- a/dsh-pet/runtime/electron-helper/sprite.js
+++ b/dsh-pet/runtime/electron-helper/sprite.js
@@ -67,6 +67,7 @@ class PetSprite {
     this.dragFollowToken = 0;
     this.throwRef = null; // 抛掷 rAF handle
     this.throwToken = 0;
+    this.space = null; // 抛掷空间（逐屏 AABB）缓存；显示器变化时由 relayout() 置空重建
     // Q 弹挤压（点击回应 / 抛掷落地）：rAF + 待压标记（等新动画成为前台再压，压新首帧）
     this.squashRef = null;
     this.squashToken = 0;
@@ -261,18 +262,49 @@ class PetSprite {
       x = this.customPos.rx * W - this.halfW;
       y = this.customPos.ry * H - this.halfH;
     } else {
+      // 角落取**主屏**而不是外接矩形：不规则多屏布局下外接矩形的角落可能不属于任何显示器
+      // （实测右倒 T 型双屏，top-left 落在主屏上方的空洞里），配了该角落的宠物开机即隐身。
       const anchor = S.anchorPixel({
         corner: this.pet.position.corner,
-        marginX: this.pet.position.marginX,
-        marginY: this.pet.position.marginY,
+        // marginX/marginY 是配置里的绝对像素，与 size 一样要吃 CONFIG.scale：开启 DPI 线性化后
+        // 坐标系是物理像素，不乘的话边距会视觉缩水（150% 缩放下 marginY:100 只剩 2/3 观感）
+        marginX: this.pet.position.marginX * CONFIG.scale,
+        marginY: this.pet.position.marginY * CONFIG.scale,
         size: this.size,
         W,
         H,
+        area: PRIMARY_AREA || undefined,
       });
       x = anchor.x;
       y = anchor.y;
     }
     this.sendBounds(x, y);
+  }
+
+  /** 抛掷空间（逐屏 AABB）。AREAS 变化时由 relayout() 置空重建——飞行中每帧重算太浪费 */
+  throwSpaceOf() {
+    if (!this.space || this.space.areas !== AREAS) {
+      this.space = S.throwSpace({ areas: AREAS, size: this.size, sideAllow: this.sideAllow });
+    }
+    return this.space;
+  }
+
+  /**
+   * 显示器几何变化（改分辨率/缩放、插拔屏、旋转）后就地重挂：
+   * 抛掷空间作废，并把宠物从可能变成空洞的位置拉回可见区。
+   * 拖拽中不动它（用户正握着，位置由指针决定）；飞行中也不动（下一帧物理自会按新边界夹取）。
+   */
+  relayout() {
+    this.space = null;
+    if (this.dragState.active || this.throwRef !== null) return;
+    this.stopMove();
+    const cx = this.pos.x + this.halfW;
+    const cy = this.pos.y + this.halfH;
+    const p = S.clampPointToRegion(AREAS, cx, cy);
+    if (p.x !== cx || p.y !== cy) {
+      this.customPos = { rx: p.x / VIEW.w, ry: p.y / VIEW.h };
+    }
+    this.position();
   }
 
   currentCenterX() {
@@ -414,9 +446,11 @@ class PetSprite {
       dir,
       minDist: mp.minDist * distScale,
       maxDist: mp.maxDist * distScale,
-      margin: mp.margin,
+      margin: mp.margin * CONFIG.scale, // 同 position() 的 marginX/marginY：绝对像素配置值须随坐标系缩放
       halfW: this.halfW,
       sideAllow: this.sideAllow,
+      // 落点按显示器并集判定：能骑缝跨屏走，但走不进外接矩形里的空洞
+      areas: AREAS,
     });
     if (!plan) return false;
     this.pendingMove = { ...plan, dir, leadSec: mp.leadSec, tailSec: mp.tailSec };
@@ -519,7 +553,7 @@ class PetSprite {
   startThrow(px, py, vx, vy) {
     this.stopDragFollow();
     this.stopMove();
-    const bounds = S.throwBounds({ W: VIEW.w, H: VIEW.h, size: this.size, sideAllow: this.sideAllow });
+    // 边界 = 显示器工作区**并集**：空洞是墙（宠物再也飞不进不可见区域），屏缝不是墙（跨屏弹跳照旧）
     const token = ++this.throwToken;
     let state = { x: px, y: py, vx, vy };
     let last = performance.now();
@@ -530,7 +564,9 @@ class PetSprite {
       const dt = (now - last) / 1000;
       last = now;
       const fallingVy = state.vy; // 本帧积分前的竖直速度（正=下落）：即落地冲击速度
-      const res = S.throwStep(state, dt, bounds, this.physics);
+      // 每帧重取：显示器变化时 relayout() 会让缓存失效，res.screen 必须与这一份对应
+      const sp = this.throwSpaceOf();
+      const res = S.throwStepRegion(state, dt, sp, this.physics);
       state = { x: res.x, y: res.y, vx: res.vx, vy: res.vy };
       this.throwState = state;
       // 上报飞行状态（节流 ~30ms）：主进程 broker 汇聚后广播，其它窗口用它做跨窗碰撞检测
@@ -570,8 +606,10 @@ class PetSprite {
         }
       }
       this.sendBounds(res.x, res.y);
-      // 落地 Q 弹：只在空中→地面转换帧触发一次，力度随冲击速度（轻落 0.8 ~ 重砸 0.55）
-      const grounded = res.y >= bounds.maxY - 1;
+      // 落地 Q 弹：只在空中→地面转换帧触发一次，力度随冲击速度（轻落 0.8 ~ 重砸 0.55）。
+      // 「地面」是**当前所在屏**的底边——多屏各有各的地面高度
+      const curBounds = sp.bounds[res.screen] || sp.bounds[0];
+      const grounded = curBounds ? res.y >= curBounds.maxY - 1 : false;
       if (res.bounced && grounded && !prevGrounded) {
         const frontEl = this.front === 0 ? this.videoA : this.videoB;
         this.startSquash(frontEl, S.landingSquash(fallingVy));
@@ -848,15 +886,21 @@ class PetSprite {
   // 退化（可视区过小/窗口整体出屏，光标也点不到宠物）返回 null → 调用方按窗口视口兜底。
   visibleClampRect() {
     // pos 是视口相对坐标，窗口屏幕位置 = pos + VIEW 原点 − 外扩余量（见 sendBounds）；
-    // 比较双方都用屏幕坐标（坐标系不混），返回的夹取矩形仍是窗口局部坐标
+    // 比较双方都用屏幕坐标（坐标系不混），返回的夹取矩形仍是窗口局部坐标。
+    // 夹取用**宠物所在的那块屏**而不是外接矩形：外接矩形含空洞，按它夹菜单会伸进
+    // 不属于任何显示器的区域（看不见）；菜单本来也不该跨屏显示。
+    const area = S.resolveRect(AREAS, this.pos.x + this.halfW, this.pos.y + this.halfH);
+    if (!area) return null;
     const winX = this.pos.x + VIEW.x - this.margin.l;
     const winY = this.pos.y + VIEW.y - this.margin.t;
     const winW = this.size + this.margin.l + this.margin.r;
     const winH = this.winH + this.margin.t + this.margin.b;
-    const vx0 = Math.max(VIEW.x, winX);
-    const vy0 = Math.max(VIEW.y, winY);
-    const vx1 = Math.min(VIEW.x + VIEW.w, winX + winW);
-    const vy1 = Math.min(VIEW.y + VIEW.h, winY + winH);
+    const ax = area.x + VIEW.x;
+    const ay = area.y + VIEW.y;
+    const vx0 = Math.max(ax, winX);
+    const vy0 = Math.max(ay, winY);
+    const vx1 = Math.min(ax + area.width, winX + winW);
+    const vy1 = Math.min(ay + area.height, winY + winH);
     const w = vx1 - vx0;
     const h = vy1 - vy0;
     if (w < 40 || h < 40) return null;

--- a/dsh-pet/scripts/test-register.mjs
+++ b/dsh-pet/scripts/test-register.mjs
@@ -1,0 +1,4 @@
+// 测试入口预载：注册 test-ts-resolver（见其头部注释）。用法：node --import ./scripts/test-register.mjs
+import { register } from 'node:module';
+
+register('./test-ts-resolver.mjs', import.meta.url);

--- a/dsh-pet/scripts/test-ts-resolver.mjs
+++ b/dsh-pet/scripts/test-ts-resolver.mjs
@@ -1,0 +1,22 @@
+/**
+ * 测试用模块解析钩子：把 src/ 里无扩展名的相对 import 补成 `.ts`。
+ *
+ * 为什么需要：src/shared 是给打包器吃的源码（moduleResolution: Bundler），相对 import 一律
+ * 不写扩展名（`./pickers`）。而单测走 `node --experimental-strip-types` 直连源文件，Node 的
+ * ESM 解析器要求完整说明符，`./pickers` 会 ERR_MODULE_NOT_FOUND。
+ *
+ * 与其为了跑测试给所有源文件加 `.ts` 后缀（需要全局打开 allowImportingTsExtensions，
+ * 且会牵动 tsdown / rolldown 两条构建链），不如只在测试进程里补这一层解析。
+ */
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    if (!/\.[cm]?[jt]sx?$/.test(specifier) && !specifier.endsWith('.json')) {
+      try {
+        return await nextResolve(specifier + '.ts', context);
+      } catch {
+        /* 落回原说明符，让 Node 报它自己的错 */
+      }
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/dsh-pet/src/shared/displays.test.ts
+++ b/dsh-pet/src/shared/displays.test.ts
@@ -1,0 +1,275 @@
+/**
+ * 多显示器几何单元测试 —— 用**实测的不规则布局**钉住边界行为。
+ *
+ * 布局：右倒 T 型双屏（副屏竖置在右，上下都超出主屏），两屏 DIP 空间严丝合缝（缝隙 0）：
+ *   主屏 DELL P2721Q  workArea 0,0 2560×1392      scaleFactor 1.5
+ *   副屏 DELL P2721Q  workArea 2560,-532 1235×2147 scaleFactor 1.75  rotation 90
+ * 关键性质：外接矩形 0,-532 3795×2147 里有 23.7% 的面积不属于任何显示器——
+ * 主屏正上方 y∈[-532,0) 与正下方 y∈[1392,1615) 两块空洞。旧实现以外接矩形为边界，
+ * 宠物会走进/飞进这两块区域并停在那里，用户完全看不到它。
+ *
+ * 坐标系：本文件直接用屏幕坐标（含负 y），验证这些函数不假定原点在 0。
+ *
+ * 跑法：node --experimental-strip-types --test src/shared/displays.test.ts
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  boundingRect,
+  clampPointToRegion,
+  indexAtPoint,
+  nearestIndex,
+  rectAtPoint,
+  regionHoleRatio,
+  translateRects,
+} from './displays.ts';
+import { anchorPixel, planMove } from './motion.ts';
+import { DEFAULT_PHYSICS, throwBounds, throwStep, throwStepRegion, throwSpace, screenOfBox } from './physics.ts';
+import { HIT_BOX } from './constants.ts';
+import type { PhysicsParams, Rect } from './types.ts';
+
+const MAIN: Rect = { x: 0, y: 0, width: 2560, height: 1392 };
+const SIDE: Rect = { x: 2560, y: -532, width: 1235, height: 2147 };
+const AREAS = [MAIN, SIDE];
+
+/** 实测宠物几何：size 462 的基准宠物 */
+const SIZE = 462;
+const PET_H = (SIZE * 9) / 16; // 259.875
+const SIDE_ALLOW = (HIT_BOX.x0 / 640) * SIZE; // 144.375
+
+const SPACE = throwSpace({ areas: AREAS, size: SIZE, sideAllow: SIDE_ALLOW });
+
+/** 抛掷步进跑到静止（或到步数上限），返回终态。dt 固定 1/60。 */
+function settle(
+  start: { x: number; y: number; vx: number; vy: number },
+  physics: PhysicsParams = DEFAULT_PHYSICS,
+  maxSteps = 4000,
+): { x: number; y: number; vx: number; vy: number; screen: number; steps: number } {
+  let s = { ...start };
+  let screen = screenOfBox(SPACE, start.x, start.y);
+  for (let i = 0; i < maxSteps; i++) {
+    const r = throwStepRegion(s, 1 / 60, SPACE, physics);
+    s = { x: r.x, y: r.y, vx: r.vx, vy: r.vy };
+    screen = r.screen;
+    if (r.atRest) return { ...s, screen, steps: i + 1 };
+  }
+  return { ...s, screen, steps: maxSteps };
+}
+
+/** 身体（包围盒内缩 sideAllow）是否被某块屏完整盖住 = 用户看得见 */
+function bodyVisible(x: number, y: number): boolean {
+  const cy = y + PET_H / 2;
+  return rectAtPoint(AREAS, x + SIDE_ALLOW, cy) !== null && rectAtPoint(AREAS, x + SIZE - SIDE_ALLOW - 1, cy) !== null;
+}
+
+describe('displays —— 并集几何', () => {
+  test('外接矩形与实测一致，且含 23.7% 空洞', () => {
+    assert.deepEqual(boundingRect(AREAS), { x: 0, y: -532, width: 3795, height: 2147 });
+    const ratio = regionHoleRatio(AREAS);
+    assert.ok(Math.abs(ratio - 0.237) < 0.001, `hole ratio ${ratio}`);
+  });
+
+  test('主屏上方/下方的空洞不属于任何显示器', () => {
+    assert.equal(rectAtPoint(AREAS, 1000, -100), null); // 主屏正上方
+    assert.equal(rectAtPoint(AREAS, 1000, 1500), null); // 主屏正下方
+    assert.equal(rectAtPoint(AREAS, 3000, -100), SIDE); // 同高度但在副屏 x 范围内：有屏
+    assert.equal(rectAtPoint(AREAS, 1000, 700), MAIN);
+  });
+
+  test('缝隙为 0：主屏右缘的下一像素就是副屏', () => {
+    assert.equal(indexAtPoint(AREAS, 2559, 700), 0);
+    assert.equal(indexAtPoint(AREAS, 2560, 700), 1);
+  });
+
+  test('空洞里的点被拉回最近的屏', () => {
+    assert.equal(nearestIndex(AREAS, 1000, -100), 0);
+    const p = clampPointToRegion(AREAS, 1000, -100);
+    assert.ok(rectAtPoint(AREAS, p.x, p.y), '夹取结果必须落在某块屏上');
+    assert.deepEqual(p, { x: 1000, y: 0 });
+    // 已在并集内的点原样返回
+    assert.deepEqual(clampPointToRegion(AREAS, 3000, -400), { x: 3000, y: -400 });
+  });
+
+  test('translateRects 把屏幕坐标搬到视口相对坐标', () => {
+    const hull = boundingRect(AREAS);
+    const local = translateRects(AREAS, -hull.x, -hull.y);
+    assert.deepEqual(local[0], { x: 0, y: 532, width: 2560, height: 1392 });
+    assert.deepEqual(local[1], { x: 2560, y: 0, width: 1235, height: 2147 });
+  });
+});
+
+describe('throwStepRegion —— 空洞是墙，屏缝不是', () => {
+  test('单块屏时与 throwStep 逐位一致', () => {
+    const only = [{ x: 0, y: 0, width: 1920, height: 1080 }];
+    const space = throwSpace({ areas: only, size: SIZE, sideAllow: SIDE_ALLOW });
+    const bounds = throwBounds({ W: 1920, H: 1080, size: SIZE, sideAllow: SIDE_ALLOW });
+    let a = { x: 300, y: 200, vx: 1700, vy: -900 };
+    let b = { ...a };
+    for (let i = 0; i < 600; i++) {
+      const ra = throwStep(a, 1 / 60, bounds, DEFAULT_PHYSICS);
+      const rb = throwStepRegion(b, 1 / 60, space, DEFAULT_PHYSICS);
+      assert.equal(rb.x, ra.x, `step ${i} x`);
+      assert.equal(rb.y, ra.y, `step ${i} y`);
+      assert.equal(rb.vx, ra.vx, `step ${i} vx`);
+      assert.equal(rb.vy, ra.vy, `step ${i} vy`);
+      assert.equal(rb.bounced, ra.bounced, `step ${i} bounced`);
+      assert.equal(rb.atRest, ra.atRest, `step ${i} atRest`);
+      a = { x: ra.x, y: ra.y, vx: ra.vx, vy: ra.vy };
+      b = { x: rb.x, y: rb.y, vx: rb.vx, vy: rb.vy };
+    }
+  });
+
+  test('主屏内向上甩：撞主屏天花板反弹，不飞进上方空洞', () => {
+    let cur = { x: 1000, y: 200, vx: 0, vy: -2500 };
+    let minY = Infinity;
+    for (let i = 0; i < 240; i++) {
+      const r = throwStepRegion(cur, 1 / 60, SPACE, DEFAULT_PHYSICS);
+      cur = { x: r.x, y: r.y, vx: r.vx, vy: r.vy };
+      minY = Math.min(minY, r.y);
+      assert.equal(r.screen, 0, `step ${i} 不该离开主屏`);
+    }
+    assert.ok(minY >= MAIN.y, `顶到 ${minY}，不得越过主屏工作区上缘 ${MAIN.y}`);
+  });
+
+  test('主屏内向右甩（高度在副屏范围内）：跨过屏缝进副屏，不被挡住', () => {
+    let cur = { x: 1800, y: 600, vx: 4200, vy: -900 };
+    let reachedSide = false;
+    for (let i = 0; i < 600 && !reachedSide; i++) {
+      const r = throwStepRegion(cur, 1 / 60, SPACE, DEFAULT_PHYSICS);
+      cur = { x: r.x, y: r.y, vx: r.vx, vy: r.vy };
+      if (r.screen === 1) reachedSide = true;
+    }
+    assert.ok(reachedSide, '宠物应当能飞进副屏（屏缝不是墙）');
+    // 之后随便怎么弹，最终落点仍须可见
+    const end = settle({ x: 1800, y: 600, vx: 4200, vy: -900 });
+    assert.ok(bodyVisible(end.x, end.y), `落点 ${end.x},${end.y} 必须可见`);
+  });
+
+  test('骑缝时不在两屏 AABB 的重叠盲区里逐帧对跳', () => {
+    // x ∈ (主屏 maxX, 副屏 minX) 这段宽 2×sideAllow 的区间，两块屏的 AABB 都不接受它。
+    // 越界即切屏的写法会在这里来回横跳；无状态判定必须让宠物匀速穿过去。
+    const lo = SPACE.bounds[0].maxX;
+    const hi = SPACE.bounds[1].minX;
+    assert.ok(hi > lo, `盲区应存在：主屏 maxX=${lo} < 副屏 minX=${hi}`);
+    let cur = { x: lo - 20, y: 600, vx: 600, vy: 0 };
+    const noGravity: PhysicsParams = { ...DEFAULT_PHYSICS, gravity: 0 };
+    for (let i = 0; i < 40; i++) {
+      const r = throwStepRegion(cur, 1 / 60, SPACE, noGravity);
+      assert.equal(r.bounced, false, `step ${i}（x=${r.x | 0}）不该在屏缝处反弹`);
+      assert.equal(r.vx, 600, `step ${i} 速度不该被改动`);
+      cur = { x: r.x, y: r.y, vx: r.vx, vy: r.vy };
+    }
+    assert.ok(cur.x > hi, `40 帧后应已穿过盲区，实际 x=${cur.x}`);
+  });
+
+  test('副屏「超出主屏的上半段」向左甩：撞空洞的墙弹回，不飞进虚空', () => {
+    // y=-400 时身体中心 ≈ -270，主屏 y 范围 [0,1392) 不含它 ⇒ 左侧无屏 ⇒ 反弹
+    let cur = { x: 2700, y: -400, vx: -2600, vy: 0 };
+    const noGravity: PhysicsParams = { ...DEFAULT_PHYSICS, gravity: 0 };
+    let minX = Infinity;
+    for (let i = 0; i < 60; i++) {
+      const r = throwStepRegion(cur, 1 / 60, SPACE, noGravity);
+      cur = { x: r.x, y: r.y, vx: r.vx, vy: r.vy };
+      minX = Math.min(minX, r.x);
+      assert.ok(bodyVisible(r.x, r.y), `step ${i}：${r.x | 0},${r.y | 0} 飞进了虚空`);
+    }
+    assert.ok(minX >= SPACE.bounds[1].minX, `最左到 ${minX}，不得越过副屏左边界 ${SPACE.bounds[1].minX}`);
+  });
+
+  test('任意方向乱甩 200 次，落点恒可见（旧实现会落进空洞）', () => {
+    let rng = 20260910;
+    const rand = (): number => (rng = (rng * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+    for (let i = 0; i < 200; i++) {
+      const fromSide = rand() < 0.5;
+      const a = fromSide ? SIDE : MAIN;
+      const x = a.x + rand() * (a.width - SIZE);
+      const y = a.y + rand() * (a.height - PET_H);
+      const end = settle({ x, y, vx: (rand() - 0.5) * 7000, vy: (rand() - 0.5) * 7000 });
+      assert.ok(
+        bodyVisible(end.x, end.y),
+        `第 ${i} 次：起点 ${x | 0},${y | 0} → 落点 ${end.x | 0},${end.y | 0} 不可见`,
+      );
+    }
+  });
+
+  test('ceilingBounce=false 时顶部仍可飞出，但只在有屏的一侧', () => {
+    const noCeil: PhysicsParams = { ...DEFAULT_PHYSICS, ceilingBounce: false };
+    const end = settle({ x: 1000, y: 100, vx: 0, vy: -3000 }, noCeil);
+    assert.ok(bodyVisible(end.x, end.y), `落点 ${end.x},${end.y} 必须回到可见区`);
+  });
+});
+
+describe('anchorPixel / planMove —— 角落与漫游不进空洞', () => {
+  test('角落按外接矩形算会掉进空洞（旧行为），按主屏算则落在主屏内', () => {
+    const hull = boundingRect(AREAS);
+    const common = { corner: 'top-left' as const, marginX: 24, marginY: 24, size: SIZE, W: hull.width, H: hull.height };
+    // 旧行为：以外接矩形为准（视口坐标 0,0 开始）——换算回屏幕坐标就是 y = -532 + 24
+    const old = anchorPixel(common);
+    assert.deepEqual(old, { x: 24, y: 24 });
+    assert.equal(rectAtPoint(AREAS, old.x + hull.x + SIDE_ALLOW, old.y + hull.y + PET_H / 2), null, '旧角落在空洞里');
+    // 新行为：传主屏工作区
+    const fixed = anchorPixel({ ...common, area: MAIN });
+    assert.deepEqual(fixed, { x: 24, y: 24 });
+    assert.ok(bodyVisible(fixed.x, fixed.y), '新角落必须可见');
+  });
+
+  test('四个角落传主屏后都落在主屏内', () => {
+    for (const corner of ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const) {
+      const p = anchorPixel({ corner, marginX: 24, marginY: 24, size: SIZE, W: 0, H: 0, area: MAIN });
+      assert.ok(bodyVisible(p.x, p.y), `${corner} → ${p.x},${p.y} 不可见`);
+    }
+  });
+
+  test('漫游落点落在空洞里时返回 null', () => {
+    const common = {
+      cy: -300, // 主屏上方的高度：只有副屏在这条线上有像素
+      W: 3795,
+      H: 2147,
+      minDist: 600,
+      maxDist: 600,
+      margin: 24,
+      halfW: SIZE / 2,
+      sideAllow: SIDE_ALLOW,
+      areas: AREAS,
+    };
+    // 从副屏往左走 600：会走出副屏左缘进入空洞 ⇒ 不可达
+    assert.equal(planMove({ ...common, cx: 2900, dir: -1 }), null);
+    // 往右走 600 仍在副屏内 ⇒ 可达
+    assert.ok(planMove({ ...common, cx: 2900, dir: 1 }));
+  });
+
+  test('同高度跨屏漫游允许（屏缝两侧都有屏，可以骑缝走过去）', () => {
+    const plan = planMove({
+      cx: 2300,
+      cy: 700, // 主屏与副屏都覆盖这条线
+      W: 3795,
+      H: 2147,
+      dir: 1,
+      minDist: 500,
+      maxDist: 500,
+      margin: 24,
+      halfW: SIZE / 2,
+      sideAllow: SIDE_ALLOW,
+      areas: AREAS,
+    });
+    assert.ok(plan, '跨屏漫游不该被屏缝挡住');
+    assert.ok(Math.abs(plan.targetRatio * 3795 - 2800) < 1);
+  });
+
+  test('不传 areas 时退化为旧的单矩形判定', () => {
+    const base = {
+      cx: 500,
+      cy: 500,
+      W: 1920,
+      H: 1080,
+      minDist: 300,
+      maxDist: 300,
+      margin: 24,
+      halfW: SIZE / 2,
+      sideAllow: SIDE_ALLOW,
+    };
+    assert.ok(planMove({ ...base, dir: 1 }));
+    assert.equal(planMove({ ...base, cx: 100, dir: -1 }), null);
+  });
+});

--- a/dsh-pet/src/shared/displays.ts
+++ b/dsh-pet/src/shared/displays.ts
@@ -1,0 +1,105 @@
+// 多显示器几何：把「桌面」建模为**工作区矩形的并集**，而不是它们的外接矩形。
+//
+// 为什么必须是并集：显示器摆放不规则时（副屏竖置且上下都超出主屏、屏幕错位排列等），
+// 外接矩形里会出现大片不属于任何显示器的**空洞**。以外接矩形为边界的漫游/抛掷/角落定位
+// 会把宠物放进空洞里——用户完全看不到它。实测一例右倒 T 型双屏：外接矩形 23.7% 的面积是空洞。
+//
+// 坐标系：本文件所有函数与调用方同坐标系即可（桌面端 = 视口相对坐标 = 屏幕坐标 − VIEW 原点），
+// 不假定原点在 0。浏览器 overlay 只有一块「屏」（视口本身），退化为单矩形，行为与以前逐位一致。
+import type { Rect } from './types';
+
+/** 矩形右缘（不含） */
+export const rectRight = (r: Rect): number => r.x + r.width;
+/** 矩形下缘（不含） */
+export const rectBottom = (r: Rect): number => r.y + r.height;
+
+/** 外接矩形：视口 VIEW 仍取它（作为坐标系原点与比例换算基准），但**边界判定一律走并集**。
+ *  空列表返回 0×0（调用方兜底）。 */
+export const boundingRect = (rects: Rect[]): Rect => {
+  if (rects.length === 0) return { x: 0, y: 0, width: 0, height: 0 };
+  let x0 = Infinity;
+  let y0 = Infinity;
+  let x1 = -Infinity;
+  let y1 = -Infinity;
+  for (const r of rects) {
+    x0 = Math.min(x0, r.x);
+    y0 = Math.min(y0, r.y);
+    x1 = Math.max(x1, rectRight(r));
+    y1 = Math.max(y1, rectBottom(r));
+  }
+  return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
+};
+
+/** 点是否落在矩形内（右/下缘不含，与 workArea 拼接语义一致：相邻两屏缝隙为 0 时点归左/上那块） */
+export const pointInRect = (r: Rect, x: number, y: number): boolean =>
+  x >= r.x && x < rectRight(r) && y >= r.y && y < rectBottom(r);
+
+/** 点被哪块屏覆盖；无则 null。重叠时取列表中第一块（与 Chromium「先发现者优先」一致） */
+export const rectAtPoint = (rects: Rect[], x: number, y: number): Rect | null => {
+  for (const r of rects) if (pointInRect(r, x, y)) return r;
+  return null;
+};
+
+/** 同上，返回下标（−1 = 无覆盖）：抛掷需要用下标记住「当前所在屏」 */
+export const indexAtPoint = (rects: Rect[], x: number, y: number): number => {
+  for (let i = 0; i < rects.length; i++) if (pointInRect(rects[i], x, y)) return i;
+  return -1;
+};
+
+/** 点到矩形的最短距离平方（点在矩形内为 0） */
+export const distToRectSq = (r: Rect, x: number, y: number): number => {
+  const dx = Math.max(r.x - x, 0, x - rectRight(r));
+  const dy = Math.max(r.y - y, 0, y - rectBottom(r));
+  return dx * dx + dy * dy;
+};
+
+/** 离点最近的屏下标（并集非空时恒有解；空列表返回 −1）。用于宠物落在空洞/屏幕被拔掉后归位 */
+export const nearestIndex = (rects: Rect[], x: number, y: number): number => {
+  let best = -1;
+  let bestD = Infinity;
+  for (let i = 0; i < rects.length; i++) {
+    const d = distToRectSq(rects[i], x, y);
+    if (d < bestD) {
+      bestD = d;
+      best = i;
+    }
+  }
+  return best;
+};
+
+/** 点所在屏；不在任何屏上时取最近的那块（恒非 null，除非列表为空） */
+export const resolveRect = (rects: Rect[], x: number, y: number): Rect | null => {
+  const hit = rectAtPoint(rects, x, y);
+  if (hit) return hit;
+  const i = nearestIndex(rects, x, y);
+  return i < 0 ? null : rects[i];
+};
+
+/** 把点夹进指定矩形（右/下缘留 1px，保证夹取结果仍满足 pointInRect） */
+export const clampPointInRect = (r: Rect, x: number, y: number): { x: number; y: number } => ({
+  x: Math.min(Math.max(x, r.x), rectRight(r) - 1),
+  y: Math.min(Math.max(y, r.y), rectBottom(r) - 1),
+});
+
+/** 把点夹进并集：已在并集内原样返回，否则夹进最近的那块屏。
+ *  用于显示器拔插/改分辨率后把落在空洞里的宠物拉回可见区。 */
+export const clampPointToRegion = (rects: Rect[], x: number, y: number): { x: number; y: number } => {
+  if (rectAtPoint(rects, x, y)) return { x, y };
+  const i = nearestIndex(rects, x, y);
+  return i < 0 ? { x, y } : clampPointInRect(rects[i], x, y);
+};
+
+/** 并集面积（各屏不重叠时 = 面积和；重叠会重复计，仅作诊断用） */
+export const regionArea = (rects: Rect[]): number => rects.reduce((s, r) => s + r.width * r.height, 0);
+
+/** 外接矩形中不属于任何显示器的面积占比 0~1（诊断/日志用；矩形不重叠时精确） */
+export const regionHoleRatio = (rects: Rect[]): number => {
+  const hull = boundingRect(rects);
+  const hullArea = hull.width * hull.height;
+  if (hullArea <= 0) return 0;
+  return Math.max(0, 1 - regionArea(rects) / hullArea);
+};
+
+/** 把一组矩形整体平移（屏幕坐标 → 视口相对坐标：减去 VIEW 原点） */
+export const translateRects = (rects: Rect[], dx: number, dy: number): Rect[] =>
+  rects.map((r) => ({ x: r.x + dx, y: r.y + dy, width: r.width, height: r.height }));

--- a/dsh-pet/src/shared/index.ts
+++ b/dsh-pet/src/shared/index.ts
@@ -9,6 +9,7 @@
 export * from './types';
 export * from './constants';
 export * from './pickers';
+export * from './displays'; // 多显示器几何（桌面 = 工作区矩形并集，而非它们的外接矩形）
 export * from './motion';
 export * from './balance';
 export * from './whisper';

--- a/dsh-pet/src/shared/motion.ts
+++ b/dsh-pet/src/shared/motion.ts
@@ -2,7 +2,8 @@
 // 坐标语义：移动规划归一化为视口比例（ratio），px 换算由调用方（rAF 驱动 / customPos）完成；
 // 角落定位返回宠物根节点左上角的像素坐标（浏览器 overlay 用 CSS 同语义，桌面模式用它摆放 sprite）。
 import { randomBetween } from './pickers';
-import type { Corner } from './types';
+import { rectAtPoint } from './displays';
+import type { Corner, Rect } from './types';
 
 /** 一次移动的几何参数（比例坐标） */
 export interface MovePlan {
@@ -14,7 +15,11 @@ export interface MovePlan {
 
 /** 计算一次移动的起点/终点比例坐标；目标越出视口边缘（含边距）时返回 null。
  *  sideAllow = 左右透明边余量（视频画布内宠物身体居中、两侧透明）：边界按"身体"贴边而不是
- *  按"整个视频盒"贴边——宠物能走到屏幕边缘，但身体永不越界（不会漫游到屏幕外丢失）。 */
+ *  按"整个视频盒"贴边——宠物能走到屏幕边缘，但身体永不越界（不会漫游到屏幕外丢失）。
+ *
+ *  areas 传入时（桌面多显示器）边界改判**工作区并集**而不是视口外接矩形：落点的身体两侧
+ *  各留 margin 后仍须落在某块屏上。缝隙两侧都有屏 ⇒ 可自由走过去（允许骑缝）；外接矩形里的
+ *  空洞没有屏 ⇒ 走不进去。不传时按 W/H 单矩形判定，浏览器 overlay 行为逐位不变。 */
 export const planMove = (o: {
   cx: number;
   cy: number;
@@ -27,14 +32,23 @@ export const planMove = (o: {
   halfW: number;
   /** 可选：身体相对视频盒左/右各留多少像素（默认 0 = 旧行为，按视频盒贴边） */
   sideAllow?: number;
+  /** 可选：显示器工作区列表（与 cx/cy 同坐标系）。给了就按并集判定落点可达性 */
+  areas?: Rect[];
 }): MovePlan | null => {
   const side = o.sideAllow ?? 0;
   const distance = randomBetween(o.minDist, o.maxDist);
   const target = o.cx + o.dir * distance;
-  // margin 语义升级为「身体到屏幕边缘的安全距」：盒中心可到 margin + halfW - side（身体左缘 = margin）
-  const leftBound = o.margin + o.halfW - side;
-  const rightBound = o.W - o.margin - o.halfW + side;
-  if (target < leftBound || target > rightBound) return null;
+  if (o.areas && o.areas.length > 0) {
+    // 身体左右缘各外扩 margin 后都得落在某块屏上（可以分属不同屏 = 允许骑缝行走）
+    const bodyHalf = o.halfW - side;
+    if (!rectAtPoint(o.areas, target - bodyHalf - o.margin, o.cy)) return null;
+    if (!rectAtPoint(o.areas, target + bodyHalf + o.margin, o.cy)) return null;
+  } else {
+    // margin 语义 =「身体到屏幕边缘的安全距」：盒中心可到 margin + halfW - side（身体左缘 = margin）
+    const leftBound = o.margin + o.halfW - side;
+    const rightBound = o.W - o.margin - o.halfW + side;
+    if (target < leftBound || target > rightBound) return null;
+  }
   return {
     startRatio: o.cx / o.W,
     startYRatio: o.cy / o.H,
@@ -51,6 +65,10 @@ export const planMove = (o: {
  *   bottom-left  = left:marginX, bottom:marginY
  *   bottom-right = right:marginX, bottom:marginY
  * 桌面模式用同一套几何摆放宠物（根节点 = 舞台）。
+ *
+ * area 传入时角落取**那块屏**而不是视口外接矩形。多显示器不规则布局下外接矩形的角落可能
+ * 压根不属于任何显示器（实测右倒 T 型双屏：top-left 落在主屏上方的空洞里，配了该角落的宠物
+ * 开机即隐身），所以桌面端必须传主屏工作区。不传时按 W/H，浏览器 overlay 行为不变。
  */
 export const anchorPixel = (o: {
   corner: Corner;
@@ -59,16 +77,23 @@ export const anchorPixel = (o: {
   size: number;
   W: number;
   H: number;
+  /** 可选：角落所属的工作区矩形（与调用方同坐标系）；缺省用 {0,0,W,H} */
+  area?: Rect;
 }): { x: number; y: number } => {
   const height = (o.size * 9) / 16;
+  const a = o.area ?? { x: 0, y: 0, width: o.W, height: o.H };
+  const left = a.x + o.marginX;
+  const top = a.y + o.marginY;
+  const right = a.x + a.width - o.size - o.marginX;
+  const bottom = a.y + a.height - height - o.marginY;
   switch (o.corner) {
     case 'top-left':
-      return { x: o.marginX, y: o.marginY };
+      return { x: left, y: top };
     case 'top-right':
-      return { x: o.W - o.size - o.marginX, y: o.marginY };
+      return { x: right, y: top };
     case 'bottom-left':
-      return { x: o.marginX, y: o.H - height - o.marginY };
+      return { x: left, y: bottom };
     case 'bottom-right':
-      return { x: o.W - o.size - o.marginX, y: o.H - height - o.marginY };
+      return { x: right, y: bottom };
   }
 };

--- a/dsh-pet/src/shared/physics.ts
+++ b/dsh-pet/src/shared/physics.ts
@@ -9,8 +9,9 @@
 // 可调参数：重力 / 弹性 / 地面摩擦来自配置顶层 physics 段（host 合并成品，全局共用）；
 // 本文件的常量只是**默认值来源**（= assets/config.jsonc 的 physics 段），
 // 运行时 throwStep 必须接收调用方传入的 PhysicsParams（浏览器/桌面都从配置成品读）。
-import type { PhysicsParams } from './types';
+import type { PhysicsParams, Rect } from './types';
 import { HIT_BOX } from './constants';
+import { indexAtPoint, nearestIndex, rectBottom, rectRight } from './displays';
 
 /** 拖拽弹簧刚度：越大跟手越紧 */
 export const SPRING_K = 200;
@@ -131,6 +132,48 @@ export interface ThrowState {
 export const throwBounds = (o: { W: number; H: number; size: number; sideAllow: number }): ThrowBounds => {
   const h = (o.size * 9) / 16;
   return { minX: -o.sideAllow, minY: 0, maxX: o.W - o.size + o.sideAllow, maxY: o.H - h };
+};
+
+/** 同 throwBounds，但基于任意一块工作区矩形（原点不必是 0）。area 取整个视口时两者逐位相同。 */
+export const throwBoundsIn = (area: Rect, size: number, sideAllow: number): ThrowBounds => {
+  const h = (size * 9) / 16;
+  return {
+    minX: area.x - sideAllow,
+    minY: area.y,
+    maxX: rectRight(area) - size + sideAllow,
+    maxY: rectBottom(area) - h,
+  };
+};
+
+/**
+ * 抛掷空间：**每块屏一套 AABB**，而不是整个桌面一个大 AABB。
+ * 不规则多屏布局下外接矩形含空洞，用它当边界会让宠物飞进不可见区域（见 shared/displays.ts 注释）。
+ */
+export interface ThrowSpace {
+  /** 逐屏的包围盒左上角允许范围（与 areas 同序） */
+  bounds: ThrowBounds[];
+  /** 逐屏工作区（判定「越界侧有没有邻屏」用） */
+  areas: Rect[];
+  /** 宠物包围盒宽 */
+  size: number;
+  /** 身体相对包围盒左右各内缩的量 */
+  sideAllow: number;
+}
+
+/** 由工作区列表构造抛掷空间（单块屏时等价于 throwBounds） */
+export const throwSpace = (o: { areas: Rect[]; size: number; sideAllow: number }): ThrowSpace => ({
+  bounds: o.areas.map((a) => throwBoundsIn(a, o.size, o.sideAllow)),
+  areas: o.areas,
+  size: o.size,
+  sideAllow: o.sideAllow,
+});
+
+/** 宠物当前该归属哪块屏：身体中心所在屏，落在空洞里时取最近的一块 */
+export const screenOfBox = (space: ThrowSpace, x: number, y: number): number => {
+  const cx = x + space.size / 2;
+  const cy = y + (space.size * 9) / 16 / 2;
+  const hit = indexAtPoint(space.areas, cx, cy);
+  return hit >= 0 ? hit : nearestIndex(space.areas, cx, cy);
 };
 
 /** 剔除超过保留窗口的旧采样（顺带排序去重，调用前采样按时间追加即可） */
@@ -260,6 +303,89 @@ export const throwStep = (
   const atRest =
     (y >= b.maxY - 1 && Math.abs(vy) < 1 && Math.abs(vx) < REST_VX) || (bounced && speed < REST_VY && Math.abs(vy) < 1);
   return { x, y, vx, vy, bounced, atRest };
+};
+
+/**
+ * 多屏抛掷步进：与 throwStep 同一套物理，唯一区别是**边界取自「身体中心所在屏」而不是整个桌面**，
+ * 且越界后多问一句「越出去的那一侧到底有没有屏」。
+ *
+ * 越界条件与 throwStep 逐字相同（`x < minX` / `x > maxX` / `y < minY` / `y >= maxY`），
+ * 命中后探一下越界侧：探测点 = 该边外第一像素 × 身体中心的另一轴坐标。
+ *   - 那里有别的屏 ⇒ **原样放行**（不夹不弹），宠物自然跨屏飞行 / 落到下一块屏；
+ *   - 那里什么都没有 ⇒ 按该边反弹。这正是外接矩形方案缺的那道墙，宠物再也飞不进空洞。
+ *
+ * 关键：放行时**不改位置也不记录「当前屏」**，下一帧照样由身体中心重新定位。
+ * 不能改成「越界即切屏」——相邻两屏的 AABB 在缝隙处留有 2×sideAllow 宽的重叠盲区
+ * （主屏 maxX = 缝 − size + sideAllow，副屏 minX = 缝 − sideAllow），骑缝的宠物落在盲区里，
+ * 切过去会立刻被新屏判为反向越界再切回来，逐帧对跳。无状态判定天然没有这个问题。
+ *
+ * 与「把屏缝当墙」相反：屏缝两侧都有屏，恒放行——DPI 一致时的跨屏弹跳手感一点不减。
+ * 单块屏时探测点恒无邻屏、恒反弹，与 throwStep 逐位一致（有单测钉住）。
+ */
+export const throwStepRegion = (
+  s: ThrowState,
+  dtRaw: number,
+  space: ThrowSpace,
+  physics: PhysicsParams = DEFAULT_PHYSICS,
+): ThrowState & { screen: number; bounced: boolean; atRest: boolean } => {
+  const dt = Math.min(Math.max(dtRaw, 0), MAX_STEP_DT);
+  let { x, y, vx, vy } = s;
+  vy += physics.gravity * dt;
+  x += vx * dt;
+  y += vy * dt;
+  if (space.areas.length === 0) return { x, y, vx, vy, screen: -1, bounced: false, atRest: false };
+
+  const h = (space.size * 9) / 16;
+  let bounced = false;
+
+  // ---- 横向：边界来自身体中心所在屏，放行与否看缝外同高度处有没有像素 ----
+  let cur = screenOfBox(space, x, y);
+  let b = space.bounds[cur];
+  let a = space.areas[cur];
+  const cy = y + h / 2;
+  if (x < b.minX) {
+    if (indexAtPoint(space.areas, a.x - 1, cy) < 0) {
+      x = b.minX;
+      vx = Math.abs(vx) * physics.restitution;
+      bounced = true;
+    }
+  } else if (x > b.maxX) {
+    if (indexAtPoint(space.areas, rectRight(a), cy) < 0) {
+      x = b.maxX;
+      vx = -Math.abs(vx) * physics.restitution;
+      bounced = true;
+    }
+  }
+
+  // ---- 纵向（横向若被夹回，身体中心可能已换屏，重新定位）----
+  cur = screenOfBox(space, x, y);
+  b = space.bounds[cur];
+  a = space.areas[cur];
+  const cx = x + space.size / 2;
+  if (y < b.minY) {
+    // ceilingBounce=false：顶部无边界，不夹不弹——宠物飞出屏幕顶部，靠重力落回
+    if (physics.ceilingBounce && indexAtPoint(space.areas, cx, a.y - 1) < 0) {
+      y = b.minY;
+      vy = Math.abs(vy) * physics.restitution;
+      bounced = true;
+    }
+  } else if (y >= b.maxY) {
+    // 下方还有一块屏（上下排布的桌面）⇒ 不当地面，继续往下掉
+    if (indexAtPoint(space.areas, cx, rectBottom(a)) < 0) {
+      y = b.maxY;
+      vx *= Math.max(0, 1 - physics.groundFriction * dt);
+      if (Math.abs(vy) < REST_VY) vy = 0;
+      else vy = -Math.abs(vy) * physics.restitution;
+      bounced = true;
+    }
+  }
+
+  cur = screenOfBox(space, x, y);
+  b = space.bounds[cur];
+  const speed = Math.hypot(vx, vy);
+  const atRest =
+    (y >= b.maxY - 1 && Math.abs(vy) < 1 && Math.abs(vx) < REST_VX) || (bounced && speed < REST_VY && Math.abs(vy) < 1);
+  return { x, y, vx, vy, screen: cur, bounced, atRest };
 };
 
 // ---- 多宠物互相碰撞（宠物 vs 宠物，仅处理「飞行中撞到被撞方」）----

--- a/dsh-pet/src/shared/types.ts
+++ b/dsh-pet/src/shared/types.ts
@@ -8,6 +8,14 @@
 /** 支持的角落 */
 export type Corner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
+/** 轴对齐矩形（左上角 + 宽高）。显示器工作区、窗口内容区、可视夹取区共用同一形状。 */
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 /**
  * 宠物的显示位置（四个值，必填）：
  * - web     = 只显示在浏览器 overlay

--- a/tools/probe-dpi.cjs
+++ b/tools/probe-dpi.cjs
@@ -1,0 +1,144 @@
+/**
+ * 多屏异构 DPI 探针：验证「同一 DIP 矩形，随窗口归属屏不同而映射到不同物理位置/尺寸」。
+ *
+ * 背景（Chromium ui/display/win/screen_win.cc）：
+ *   ScreenWin::DIPToScreenRect(hwnd, dip) 用 **hwnd 当前所在屏** 的 (dipOrigin, pixelOrigin, scale)
+ *   做仿射变换 —— origin 走 DIPToScreenPoint(dip.origin, thatDisplay)，size 走 dip.size × thatDisplay.scale。
+ *   hwnd 归属由 MonitorFromWindow(MONITOR_DEFAULTTONEAREST) 按面积占比决定，骑缝时会翻转。
+ *   两屏 scale 不同 ⇒ 翻转前后同一 DIP 值落到不同物理像素；scale 相同 ⇒ 两屏共用同一仿射变换，翻转无影响。
+ *
+ * 跑法（harness 自带 electron）：
+ *   %APPDATA%\dsh-desktop-dev\harness\electron\electron.exe tools\probe-dpi.cjs
+ *   %APPDATA%\dsh-desktop-dev\harness\electron\electron.exe tools\probe-dpi.cjs --force-device-scale-factor=1
+ *
+ * 判读：DELTA 段全为 0 = 该 DIP 值不受窗口归属影响（DPI 换算已线性化）；非 0 = 骑缝翻转会跳变，
+ * 数值即跳变幅度（物理像素）。加 --force-device-scale-factor 后应全部归零。
+ */
+'use strict';
+const { app, BrowserWindow, screen } = require('electron');
+
+const forced = process.argv.find((a) => a.startsWith('--force-device-scale-factor='));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fmt = (r) => `${r.x},${r.y} ${r.width}×${r.height}`;
+
+/** 把窗口挪到指定屏并等 Windows 处理完 WM_DPICHANGED / 归属更新 */
+async function park(win, display) {
+  const a = display.workArea;
+  win.setContentBounds({ x: Math.round(a.x + 20), y: Math.round(a.y + 20), width: 200, height: 200 }, false);
+  await sleep(250);
+  return screen.getDisplayNearestPoint(win.getBounds()).id;
+}
+
+app.whenReady().then(async () => {
+  const displays = screen.getAllDisplays();
+  console.log('=== DISPLAYS ===');
+  for (const [i, d] of displays.entries()) {
+    console.log(
+      `  #${i} ${d.label} id=${d.id} scale=${d.scaleFactor} rot=${d.rotation}` +
+        `  bounds=${fmt(d.bounds)}  workArea=${fmt(d.workArea)}`,
+    );
+  }
+  console.log('forceDeviceScaleFactor =', forced || '(none)');
+  // 全局线性化是否成立：DIP↔物理 是不是一个与「归属哪块屏」无关的单一仿射变换。
+  // 充要条件是每块屏都满足 pixelOrigin == dipOrigin × scale（原点与缩放同源）。
+  // dipToScreenRect(null, r) 让 Chromium 自己按矩形位置挑屏，与逐屏推算对照即可看出偏移。
+  console.log('\n=== 逐屏仿射一致性（dipOrigin×scale vs 实际 pixelOrigin） ===');
+  for (const [i, d] of displays.entries()) {
+    const oneDip = { x: d.bounds.x, y: d.bounds.y, width: 10, height: 10 };
+    const phys = screen.dipToScreenRect(null, oneDip);
+    console.log(
+      `  #${i} dipOrigin=${d.bounds.x},${d.bounds.y} ×${d.scaleFactor} => 期望 ${d.bounds.x * d.scaleFactor},${
+        d.bounds.y * d.scaleFactor
+      }   实际 pixelOrigin=${phys.x},${phys.y}`,
+    );
+  }
+
+  // 外接矩形 vs 工作区并集面积：P1 空洞占比
+  const x0 = Math.min(...displays.map((d) => d.workArea.x));
+  const y0 = Math.min(...displays.map((d) => d.workArea.y));
+  const x1 = Math.max(...displays.map((d) => d.workArea.x + d.workArea.width));
+  const y1 = Math.max(...displays.map((d) => d.workArea.y + d.workArea.height));
+  const hullArea = (x1 - x0) * (y1 - y0);
+  const sumArea = displays.reduce((s, d) => s + d.workArea.width * d.workArea.height, 0);
+  console.log('\n=== HULL vs UNION ===');
+  console.log(`hull = ${x0},${y0} ${x1 - x0}×${y1 - y0}  area=${hullArea}`);
+  console.log(`sum(workArea) = ${sumArea}   hole = ${(((hullArea - sumArea) / hullArea) * 100).toFixed(1)}%`);
+
+  const win = new BrowserWindow({
+    width: 200,
+    height: 200,
+    show: true,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    useContentSize: true,
+    webPreferences: { offscreen: false },
+  });
+  win.setIgnoreMouseEvents(true, { forward: true });
+  await sleep(300);
+
+  // 测试用 DIP 矩形：宠物窗口典型尺寸 924×600，取缝隙两侧 + 各屏深处
+  const W = 924;
+  const H = 600;
+  // tag 必须带下标：同型号双屏 label 完全相同，用 label 做 key 会互相覆盖
+  const probes = [];
+  displays.forEach((d, i) => {
+    const a = d.workArea;
+    probes.push({ tag: `#${i} ${d.label}@origin`, x: a.x + 10, y: a.y + 10 });
+    probes.push({
+      tag: `#${i} ${d.label}@center`,
+      x: Math.round(a.x + a.width / 2 - W / 2),
+      y: Math.round(a.y + a.height / 2),
+    });
+    probes.push({ tag: `#${i} ${d.label}@far-edge`, x: Math.round(a.x + a.width - W - 10), y: Math.round(a.y + 10) });
+  });
+
+  const table = [];
+  for (const [i, d] of displays.entries()) {
+    const parkedOn = await park(win, d);
+    const row = { parkedOn: `#${i} ${d.label}(id=${d.id}, scale=${d.scaleFactor})`, nearest: parkedOn, map: {} };
+    for (const p of probes) {
+      row.map[p.tag] = screen.dipToScreenRect(win, { x: p.x, y: p.y, width: W, height: H });
+    }
+    table.push(row);
+  }
+
+  console.log('\n=== DIP → PHYSICAL, 按窗口停放屏分组 ===');
+  console.log(`测试矩形 DIP 尺寸 = ${W}×${H}`);
+  for (const row of table) {
+    console.log(`\n-- 窗口停在 ${row.parkedOn} --`);
+    for (const [tag, r] of Object.entries(row.map)) console.log(`   ${tag.padEnd(28)} → ${fmt(r)}`);
+  }
+
+  if (table.length >= 2) {
+    console.log('\n=== DELTA（第 2 组 − 第 1 组；全 0 = 与窗口归属无关） ===');
+    const a = table[0].map;
+    const b = table[1].map;
+    for (const tag of Object.keys(a)) {
+      const d = {
+        dx: b[tag].x - a[tag].x,
+        dy: b[tag].y - a[tag].y,
+        dw: b[tag].width - a[tag].width,
+        dh: b[tag].height - a[tag].height,
+      };
+      const flag = d.dx || d.dy || d.dw || d.dh ? '  <-- 跳变' : '';
+      console.log(`   ${tag.padEnd(28)} dx=${d.dx} dy=${d.dy} dw=${d.dw} dh=${d.dh}${flag}`);
+    }
+  }
+
+  // setContentBounds 往返：设 DIP → 读回 DIP，看主进程「回读去重」为何永远不相等
+  console.log('\n=== setContentBounds 往返（读回 ≠ 设定 ⇒ 回读去重必然每帧重设） ===');
+  for (const d of displays) {
+    const a = d.workArea;
+    const target = { x: Math.round(a.x + a.width / 2 - W / 2), y: Math.round(a.y + 100), width: W, height: H };
+    win.setContentBounds(target, false);
+    await sleep(250);
+    const back = win.getContentBounds();
+    const same = target.x === back.x && target.y === back.y && target.width === back.width && target.height === back.height;
+    console.log(`   ${d.label}(scale=${d.scaleFactor}): set ${fmt(target)} → get ${fmt(back)}  ${same ? 'equal' : 'DIFF'}`);
+  }
+
+  win.destroy();
+  app.exit(0);
+});


### PR DESCRIPTION
这个 bug 比预计的复杂，重新做了一遍问题定位，换成了全新的修复方案（接替已关闭的 #45）。

我自己电脑外接4K双屏（主屏横向150%缩放，副屏纵向175%缩放，呈现右倒T字型布局）实测完美符合预期。
应该也可以解决 #44 的问题，断开一个屏幕单屏测试也没有再出现Bug。

## 跨屏闪烁的真正根因

是 **DIP→物理 换算不唯一**。

Windows 上 Chromium 的 `ScreenWin::DIPToScreenRect(hwnd, rect)` 用「hwnd 当前归属屏」的一组参数做仿射变换：

```
physical = (dip − D.dipOrigin) × D.scale + D.pixelOrigin
```

而 `D` 由 `MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)` 决定，即**窗口面积占比最大的那块屏**。宠物窗口宽约两倍宠物宽，跨缝要几十帧，期间归属在临界点反复翻转；两屏缩放不同时，同一个 DIP 值在翻转前后落到不同物理位置、算出不同物理尺寸，`setContentBounds` 每帧的落点就在两套坐标系之间横跳。

这解释了一个之前想不通的现象：**两屏缩放一致时同样骑缝却毫无问题**——那时所有屏共用同一个仿射变换，翻转不产生任何差异。

实测（`tools/probe-dpi.cjs`，1.5 + 1.75 双屏）同一个 924×600 的 DIP 矩形，仅因窗口停放屏不同：

| 探测点 | 位置偏差 | 尺寸偏差 |
|---|---|---|
| 靠近屏缝 | 3 px | 232×151 px |
| 屏幕中央 | 39 px | 231×151 px |
| 远离屏缝 | 75 px | 231×151 px |

顺带说明为什么不能靠「把窗口夹进单屏、禁止骑缝」来绕开：窗口在缝隙附近会被反复夹回，而抛掷边界允许身体贴边（`sideAllow`），夹取后的窗口表达不了这段越界，结果是肉眼可见的抖动与反弹粘滞。

## 改法

### 一、`--force-device-scale-factor=1`（main.js）

让 Chromium 的 `GetMonitorScaleFactors()` 对所有显示器返回同一个值，全部屏塌缩成同一个仿射变换 ⇒ `DIPToScreenRect` 的结果与窗口归属无关，骑缝翻转不再产生跳变。窗口可以自由骑缝，跨屏拖拽与弹跳的手感一点不减。

值必须是 1，不能取主屏的 scaleFactor：实测 forced=1.5 时 `display.bounds` 被二次缩放（主屏物理 3840 宽报成 1706 = 3840/1.5/1.5，而同一块屏的 `workArea` 报 2560 = 3840/1.5，两者自相矛盾），`pixelOrigin ≠ dipOrigin×scale`，副屏反而多出 1281px 的**恒定**偏移，比不加 switch 还糟。取 1 时每块屏都满足 `pixelOrigin == dipOrigin×scale`，探针 DELTA 全 0。

代价是宠物尺寸与配置里的绝对像素边距（`position.marginX/marginY`、`moves.margin`）单位变成物理像素，统一乘上探测到的真实主屏 scaleFactor 抵掉，观感与修复前一致。switch 必须在 app ready 之前设、而那时 `screen` 模块还不可用，所以首次启动 spawn 一个自己的探测子进程（`DSH_PET_DPI_PROBE=1`，只打印 scaleFactor 就退出，约 0.5s）读值落盘，之后每次启动直接读缓存、零开销；探测失败则整个机制不启用，退回修复前行为。

### 二、桌面几何从「工作区外接矩形」改为「工作区并集」（src/shared/）

外接矩形在不规则布局下含大片不属于任何显示器的空洞（实测右倒 T 型双屏 23.7%），宠物会走进或飞进去停在那里，用户完全看不到。

`physics.ts` 新增 `throwSpace` / `throwStepRegion`：越界条件与原 `throwStep` 逐字相同，命中后多探一句越界侧有没有屏——有就原样放行（跨屏飞行、或落到下一块屏），没有才反弹。屏缝两侧都有屏、恒放行；空洞成为一道墙。`motion.ts` 的 `planMove` 落点同理按并集判定。

一个值得记的坑：判定必须**无状态**。相邻两屏的 AABB 在缝隙处留有 `2×sideAllow` 宽的重叠盲区（主屏 `maxX = 缝−size+sideAllow`，副屏 `minX = 缝−sideAllow`），骑缝的宠物正落在盲区里，写成「越界即切屏」会立刻被新屏判为反向越界再切回来，逐帧对跳。改成每帧由身体中心重新定位、放行时不改任何状态即可。

### 三、其他问题的修复

- `anchorPixel` 改按主屏工作区算角落。按外接矩形算时 `top-left` 可能落在空洞里（实测布局下就是），配了该角落的宠物开机即隐身。
- 桌面几何支持热更新。此前只在建窗口时算一次并经 URL query 注入，运行期永不更新（改分辨率或插拔屏后可移动范围还是旧的）。主进程监听 `display-metrics-changed` / `-added` / `-removed` 重算并经 `pet:displays` 推送，渲染端就地重挂。
- `setContentBounds` 去重比较**上一次请求的值**而非 `getContentBounds()` 回读值。跨缩放屏往返有 `ScaleToEnclosingRect`（向外取整）与 origin 舍入，读回值与设定值永远不等（实测 set 924×600 得 792×514），拿它去重反而变成每帧强制重设窗口。
- `renderer` 的 resize 回调加守卫，拖拽/飞行/漫游中不再调 `position()`。跨屏时 Windows 的 `WM_DPICHANGED` 恰好会触发它，把宠物拉回上一个落点。
- Helper 显式 `app.setName`。被 `electron.exe <main.js>` 直接拉起时 app 名回落成 "Electron"，userData 与 Chromium profile 会落进 `%APPDATA%\Electron` 这个公共目录。

## 与 #44 各症状的对应

- 「拖动到新屏幕动画来回闪现」「有几率拖不过去」→ 改法一，根因修复。
- 「右键菜单还是会被裁剪」→ 菜单夹取矩形由「窗口 ∩ 外接矩形」改为「窗口 ∩ 宠物所在屏」。外接矩形不裁空洞，菜单会伸进不属于任何显示器的区域；报告中 2560×1600 + 1920×1080 的布局若非顶部对齐即存在这类空洞。
- 评论中补报的「两屏分辨率不一致时，从大屏到小屏宠物下落会超过任务栏、彻底看不到」→ 改法二。地面高度原先取外接矩形底边（= 最靠下那块屏的底边），宠物在小屏上会掉到小屏可视区之外；现在地面是**宠物所在屏的 `workArea` 底边**，而 `workArea` 本身已排除任务栏。

## 关于验证

几何部分不需要多屏环境就能验证：`npm test` 跑 `src/shared/displays.test.ts` 共 17 项，用实测布局数据钉住行为，其中一项专门断言**单块屏时 `throwStepRegion` 与原 `throwStep` 逐位一致**（位置/速度/反弹/静止四个量逐帧比对 600 帧），另一项是「任意方向乱甩 200 次落点恒可见」。

DPI 部分对单显示器的影响：

- 单屏 + 100% 缩放：补偿因子为 1，与修复前逐位相同。
- 单屏 + 非 100% 缩放：坐标系由 DIP 变为物理像素，宠物尺寸/边距/移动距离按同一因子等比补偿，观感一致；几何逻辑本身由上面那条逐位一致的单测兜住。
- 不放心可用 `DSH_PET_FORCE_DSF=0` 一键关闭整个机制，退回修复前行为（也便于对比排障）。

`tools/probe-dpi.cjs` 可复跑本 PR 引用的全部 DIP↔物理 实测，加 `--force-device-scale-factor=1` 对照即可看出线性化是否成立（DELTA 应全为 0）。

## Test plan

- [x] 双屏异构 DPI（1.5 + 1.75，右倒 T 型）拖拽穿过屏缝：位置连续，无分身闪烁
- [x] 副屏抛甩、跨屏来回弹跳：只有一只，无闪烁
- [x] 往主屏正上方/正下方（外接矩形的空洞）大力甩：撞墙弹回，不再消失
- [x] 副屏超出主屏的上半段向左甩：在副屏左缘弹回，不飞进虚空
- [x] 右键「回到初始位置」落在主屏角落；贴边右键菜单完整显示
- [x] 运行期改分辨率/缩放：可移动范围立即跟随
- [x] 单显示器回归（漫游 / 抛掷 / 角落定位 / 菜单）