### PR TITLE
fix: drop defunct @deepseek-ai/dsh-client-runtime from client deps

### DIFF
--- a/dsh-pet/package.json
+++ b/dsh-pet/package.json
@@ -88,7 +88,6 @@
     },
     "client": {
       "inject": [
-        "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-connection"
       ],
       "platform": "web"
@@ -98,7 +97,6 @@
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
     "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
     "@deepseek-ai/dsh-client-ui-slots": "^0.1.1-rc.2",
     "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
     "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",


### PR DESCRIPTION
`@deepseek-ai/dsh-client-runtime` 在 npm 上止于 **`0.1.1-rc.2`**（最后一次发布变更 2026-08-21），DSH 0.1.5 已用 `@deepseek-ai/dsh-client-modules` 取代它。本仓库的 `dsh-pet/package.json` 仍在 `dsh.client.inject` 与 `peerDependencies` 中声明它。

这与你在 #50 中处理的是同一轮 0.1.5 适配 —— 那次迁移改了通知通道（`fix(notify): 系统通知改走 host 转发通道适配 DSH 0.1.5 事件 API`，即当前 `main` 的 HEAD `6180c8a`），而这里的失效声明是同一轮迁移的遗漏项。

## 改动

`dsh-pet/package.json`，2 行删除：

- `dsh.client.inject`：移除 `"@deepseek-ai/dsh-client-runtime"`
- `peerDependencies`：移除 `"@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2"`（11 → 10 项）

`dsh.client.inject` 保留 `"@deepseek-ai/dsh-client-connection"`（该包仍在发布，最新 `0.1.5-rc.2`，且处于前端静态模块表中）。

## 为什么判断它已失效

当前 DSH 核心包中**没有任何一个注入 `dsh-client-runtime`**，逐包核对结果：

```
dsh-cordis-client-runner    inject: ..., @deepseek-ai/dsh-client-modules, ...
dsh-client-ui-chat          inject: ..., @deepseek-ai/dsh-client-locale, ...
dsh-client-ui-conversation  inject: ..., @deepseek-ai/dsh-client-file-upload, ...
dsh-client-ui-sidebar       inject: ..., @deepseek-ai/dsh-client-ui-renderer, ...
dsh-client-ui-settings      inject: @deepseek-ai/dsh-api-remotes
dsh-client-connection       inject: (无)
```

## 这不会改变运行时行为

需要明确的是，**这不是运行时故障的修复**。客户端模块加载器对 `inject` 中无法对应到启动图行的条目是静默跳过的（`@deepseek-ai/dsh-client-modules/lib/client.js`，`arriveGraphRow` 中 `graphRows.get(packageName)` 未命中即 continue），而 dsh-pet 的客户端 bundle 实测只 `require("react")` 与 `require("react/jsx-runtime")`，并无对该运行时的引用。

所以这是一次**清理失效声明**的改动，实际收益是两点：

1. `peerDependencies` 里少一个永远不会被满足的条目 —— `^0.1.1-rc.2` 在语义化版本上无法靠升到 `0.1.5-rc.2` 满足（0.x 的 `^` 锁 minor），未来的依赖审计工具会持续把它报成缺失 peer。
2. 不再把一个已不存在的包名写进 `dsh.client.inject`，避免读者误以为 0.1.5 仍提供该模块。

## 验证方法

在 DSH `0.1.5-rc.1` + `dsh-pet@0.2.8` 实机上，从运行中的 web 服务抓取 `window.__DSH_BOOT__` 启动清单，确认 dsh-pet 那一行为：

```
dsh-pet
  inject: @deepseek-ai/dsh-client-runtime, @deepseek-ai/dsh-client-connection
  external: (无)
```

`external`（即加载器真正用于建图与校验依赖的字段）为空，佐证 `inject` 中这两项都不构成硬依赖；移除失效项后启动清单无变化，插件照常挂载。

如果这个改动你认可，我也可以顺手把 `inject` 里剩余的客户端包名与当前前端静态模块表（`react` / `react-dom` / `react-dom/client` / `react/jsx-runtime` / `@deepseek-ai/cordis` / `dsh-client-store` / `dsh-client-ui-slots` / `dsh-client-ui-primitives` / `dsh-client-ui-dockkit`）对齐，但那属于另一件事，这次的 diff 就保持最小。
